### PR TITLE
Adding a location radius overlay to the PowerSkiller plugin

### DIFF
--- a/powerskiller/src/main/java/net/runelite/client/plugins/powerskiller/PowerSkillerConfiguration.java
+++ b/powerskiller/src/main/java/net/runelite/client/plugins/powerskiller/PowerSkillerConfiguration.java
@@ -442,6 +442,18 @@ public interface PowerSkillerConfiguration extends Config
 	{
 		return 10;
 	}
+	
+	@ConfigItem(
+			keyName = "drawLocationRadius",
+			name = "Draw Location Radius",
+			description = "Draw location Radius on screen.",
+			position = 131,
+			titleSection = "skillerTitle"
+	)
+	default boolean drawlocationRadius()
+	{
+		return false;
+	}
 
 	@ConfigItem(
 		keyName = "safeSpot",

--- a/powerskiller/src/main/java/net/runelite/client/plugins/powerskiller/PowerSkillerOverlay.java
+++ b/powerskiller/src/main/java/net/runelite/client/plugins/powerskiller/PowerSkillerOverlay.java
@@ -9,11 +9,13 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
+import net.runelite.api.Perspective;
 import static net.runelite.api.MenuOpcode.RUNELITE_OVERLAY_CONFIG;
 import static net.runelite.client.ui.overlay.OverlayManager.OPTION_CONFIGURE;
 import net.runelite.client.ui.overlay.OverlayMenuEntry;
 import net.runelite.client.ui.overlay.OverlayPanel;
 import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.OverlayUtil;
 import net.runelite.client.ui.overlay.components.TitleComponent;
 import net.runelite.client.ui.overlay.components.table.TableAlignment;
 import net.runelite.client.ui.overlay.components.table.TableComponent;
@@ -35,7 +37,7 @@ class PowerSkillerOverlay extends OverlayPanel
 	private PowerSkillerOverlay(final Client client, final PowerSkillerPlugin plugin, final PowerSkillerConfiguration config)
 	{
 		super(plugin);
-		setPosition(OverlayPosition.BOTTOM_LEFT);
+		setPosition(OverlayPosition.DYNAMIC);
 		this.client = client;
 		this.plugin = plugin;
 		this.config = config;
@@ -49,6 +51,15 @@ class PowerSkillerOverlay extends OverlayPanel
 		{
 			log.debug("Overlay conditions not met, not starting overlay");
 			return null;
+		}
+		if(config.drawlocationRadius())
+		{
+			try
+			{
+				OverlayUtil.renderPolygon(graphics, Perspective.getCanvasTileAreaPoly(client, client.getLocalPlayer().getLocalLocation(),config.locationRadius()), ColorUtil.fromHex("#121212"));
+			} catch (Exception ignored) {
+				//Perspective can not find the Polygon to draw on the map.
+			}
 		}
 		TableComponent tableComponent = new TableComponent();
 		tableComponent.setColumnAlignments(TableAlignment.LEFT, TableAlignment.RIGHT);


### PR DESCRIPTION
- Added a boolean config item 'Draw Location Radius'.
- If config item is checked and the usual requirements for the overlay are met, the location radius will be drawn in game.

**ISSUES**
- [ ] Had to use `setPosition(OverlayPosition.DYNAMIC);` which led to the regular overlay being forced to the top left corner.
- [ ] If the regular overlay is moved using alt+drag, the location radius also moves with it.