### PR TITLE
powerfighter: checks rune pouch for nature and fire runes

### DIFF
--- a/botutils/src/main/java/net/runelite/client/plugins/botutils/BotUtils.java
+++ b/botutils/src/main/java/net/runelite/client/plugins/botutils/BotUtils.java
@@ -1582,9 +1582,19 @@ public class BotUtils extends Plugin
 
 	public boolean runePouchContains(int id)
 	{
-
-		Set<Integer> runePouchIds = Stream.of(Runes.getRune(client.getVar(Varbits.RUNE_POUCH_RUNE1)).getItemId(),Runes.getRune(client.getVar(Varbits.RUNE_POUCH_RUNE2)).getItemId(),
-				Runes.getRune(client.getVar(Varbits.RUNE_POUCH_RUNE3)).getItemId()).collect(Collectors.toSet());
+		Set<Integer> runePouchIds = new HashSet<>();
+		if(client.getVar(Varbits.RUNE_POUCH_RUNE1)!=0)
+		{
+			runePouchIds.add(Runes.getRune(client.getVar(Varbits.RUNE_POUCH_RUNE1)).getItemId());
+		}
+		if (client.getVar(Varbits.RUNE_POUCH_RUNE2)!=0)
+		{
+			runePouchIds.add(Runes.getRune(client.getVar(Varbits.RUNE_POUCH_RUNE2)).getItemId());
+		}
+		if (client.getVar(Varbits.RUNE_POUCH_RUNE3)!=0)
+		{
+			runePouchIds.add(Runes.getRune(client.getVar(Varbits.RUNE_POUCH_RUNE3)).getItemId());
+		}
 		for(int runePouchId : runePouchIds){
 			if(runePouchId==id){
 				return true;

--- a/botutils/src/main/java/net/runelite/client/plugins/botutils/BotUtils.java
+++ b/botutils/src/main/java/net/runelite/client/plugins/botutils/BotUtils.java
@@ -1612,6 +1612,29 @@ public class BotUtils extends Plugin
 		}
 		return true;
 	}
+	
+	public int runePouchQuanitity(int id)
+	{
+		Set<Pair<Integer, Integer>> runePouchSlots = new HashSet<>();
+		if(client.getVar(Varbits.RUNE_POUCH_RUNE1)!=0)
+		{
+			runePouchSlots.add(new Pair<Integer, Integer>(Runes.getRune(client.getVar(Varbits.RUNE_POUCH_RUNE1)).getItemId(),client.getVar(Varbits.RUNE_POUCH_AMOUNT1)));
+		}
+		if (client.getVar(Varbits.RUNE_POUCH_RUNE2)!=0)
+		{
+			runePouchSlots.add(new Pair<Integer, Integer>(Runes.getRune(client.getVar(Varbits.RUNE_POUCH_RUNE2)).getItemId(),client.getVar(Varbits.RUNE_POUCH_AMOUNT2)));
+		}
+		if (client.getVar(Varbits.RUNE_POUCH_RUNE3)!=0)
+		{
+			runePouchSlots.add(new Pair<Integer, Integer>(Runes.getRune(client.getVar(Varbits.RUNE_POUCH_RUNE3)).getItemId(),client.getVar(Varbits.RUNE_POUCH_AMOUNT3)));
+		}
+		for(Pair<Integer, Integer> pair : runePouchSlots){
+			if(pair.getKey()==id){
+				return pair.getValue();
+			}
+		}
+		return 0;
+	}
 
 	/**
 	 * BANKING FUNCTIONS

--- a/powerfighter/src/main/java/net/runelite/client/plugins/powerfighter/PowerFighterPlugin.java
+++ b/powerfighter/src/main/java/net/runelite/client/plugins/powerfighter/PowerFighterPlugin.java
@@ -289,7 +289,7 @@ public class PowerFighterPlugin extends Plugin
 		return config.alchItems() &&
 			client.getBoostedSkillLevel(Skill.MAGIC) >= 55 &&
 			((utils.inventoryContains(ItemID.NATURE_RUNE) && utils.inventoryContainsStack(ItemID.FIRE_RUNE, 5)) 
-				|| (utils.runePouchContains(554) && utils.runePouchContains(561)));
+				|| (utils.runePouchQuanitity(554)>=5 && utils.runePouchContains(561)));
 	}
 
 	private boolean alchableItem(int itemID)

--- a/powerfighter/src/main/java/net/runelite/client/plugins/powerfighter/PowerFighterPlugin.java
+++ b/powerfighter/src/main/java/net/runelite/client/plugins/powerfighter/PowerFighterPlugin.java
@@ -288,7 +288,8 @@ public class PowerFighterPlugin extends Plugin
 	{
 		return config.alchItems() &&
 			client.getBoostedSkillLevel(Skill.MAGIC) >= 55 &&
-			utils.inventoryContains(ItemID.NATURE_RUNE) && utils.inventoryContainsStack(ItemID.FIRE_RUNE, 5);
+			((utils.inventoryContains(ItemID.NATURE_RUNE) && utils.inventoryContainsStack(ItemID.FIRE_RUNE, 5)) 
+				|| (utils.runePouchContains(554) && utils.runePouchContains(561)));
 	}
 
 	private boolean alchableItem(int itemID)


### PR DESCRIPTION
BotUtils runePouchContains function now correctly checks runes even if the rune pouch is not full.
PowerFighter function now checks for nature runes and fire runes in your rune pouch.