### PR TITLE
BotUtils: Remove double usages and give MouseEvents names.

### DIFF
--- a/botutils/src/main/java/net/runelite/client/plugins/botutils/BotUtils.java
+++ b/botutils/src/main/java/net/runelite/client/plugins/botutils/BotUtils.java
@@ -817,7 +817,7 @@ public class BotUtils extends Plugin
 		click(point);
 	}
 
-	public void click(Point p)
+	public void click(Point point)
 	{
 		assert !client.isClientThread();
 
@@ -827,15 +827,11 @@ public class BotUtils extends Plugin
 			final Dimension real = client.getRealDimensions();
 			final double width = (stretched.width / real.getWidth());
 			final double height = (stretched.height / real.getHeight());
-			final Point point = new Point((int) (p.getX() * width), (int) (p.getY() * height));
-			mouseEvent(501, point);
-			mouseEvent(502, point);
-			mouseEvent(500, point);
-			return;
+			point = new Point((int) (point.getX() * width), (int) (point.getY() * height));
 		}
-		mouseEvent(501, p);
-		mouseEvent(502, p);
-		mouseEvent(500, p);
+		mouseEvent(MouseEvent.MOUSE_PRESSED, point);
+		mouseEvent(MouseEvent.MOUSE_RELEASED, point);
+		mouseEvent(MouseEvent.MOUSE_CLICKED, point);
 	}
 
 	public void moveClick(Rectangle rectangle)
@@ -846,7 +842,7 @@ public class BotUtils extends Plugin
 		moveClick(point);
 	}
 
-	public void moveClick(Point p)
+	public void moveClick(Point point)
 	{
 		assert !client.isClientThread();
 
@@ -856,21 +852,14 @@ public class BotUtils extends Plugin
 			final Dimension real = client.getRealDimensions();
 			final double width = (stretched.width / real.getWidth());
 			final double height = (stretched.height / real.getHeight());
-			final Point point = new Point((int) (p.getX() * width), (int) (p.getY() * height));
-			mouseEvent(504, point);
-			mouseEvent(505, point);
-			mouseEvent(503, point);
-			mouseEvent(501, point);
-			mouseEvent(502, point);
-			mouseEvent(500, point);
-			return;
+			point = new Point((int) (point.getX() * width), (int) (point.getY() * height));
 		}
-		mouseEvent(504, p);
-		mouseEvent(505, p);
-		mouseEvent(503, p);
-		mouseEvent(501, p);
-		mouseEvent(502, p);
-		mouseEvent(500, p);
+		mouseEvent(MouseEvent.MOUSE_ENTERED, point);
+		mouseEvent(MouseEvent.MOUSE_EXITED, point);
+		mouseEvent(MouseEvent.MOUSE_MOVED, point);
+		mouseEvent(MouseEvent.MOUSE_PRESSED, point);
+		mouseEvent(MouseEvent.MOUSE_RELEASED, point);
+		mouseEvent(MouseEvent.MOUSE_CLICKED, point);
 	}
 
 	public Point getClickPoint(@NotNull Rectangle rect)
@@ -889,7 +878,7 @@ public class BotUtils extends Plugin
 		moveClick(point);
 	}
 
-	public void moveMouseEvent(Point p)
+	public void moveMouseEvent(Point point)
 	{
 		assert !client.isClientThread();
 
@@ -899,15 +888,11 @@ public class BotUtils extends Plugin
 			final Dimension real = client.getRealDimensions();
 			final double width = (stretched.width / real.getWidth());
 			final double height = (stretched.height / real.getHeight());
-			final Point point = new Point((int) (p.getX() * width), (int) (p.getY() * height));
-			mouseEvent(504, point);
-			mouseEvent(505, point);
-			mouseEvent(503, point);
-			return;
+			point = new Point((int) (point.getX() * width), (int) (point.getY() * height));
 		}
-		mouseEvent(504, p);
-		mouseEvent(505, p);
-		mouseEvent(503, p);
+		mouseEvent(MouseEvent.MOUSE_ENTERED, point);
+		mouseEvent(MouseEvent.MOUSE_EXITED, point);
+		mouseEvent(MouseEvent.MOUSE_MOVED, point);
 	}
 
 	public int getRandomIntBetweenRange(int min, int max)


### PR DESCRIPTION
I made it override the main Point so you dont need MouseEvent at 2 places and give the MouseEvents names instead of numbers.