### PR TITLE
openosrsVersion change

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -24,8 +24,10 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import
+
 object ProjectVersions {
-    const val openosrsVersion = "3.4.5"
+    const val openosrsVersion = "3.5.2"
     const val apiVersion = "0.0.1"
 }
 

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -24,8 +24,6 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import
-
 object ProjectVersions {
     const val openosrsVersion = "3.5.2"
     const val apiVersion = "0.0.1"


### PR DESCRIPTION
change required in order to clone the repository, otherwise would receive the following error:
Could not find any version that matches com.openosrs:runelite-api:3.4.5+.
Versions that do not match:
  - 3.5.2
  - maven-metadata-local.xml
Required by:
    project :imagiccaster

Possible solution:
 - Declare repository providing the artifact, see the documentation at https://docs.gradle.org/current/userguide/declaring_repositories.html