### PR TITLE
iUtils: 'prevent afk' set to false by default

### DIFF
--- a/iutils/iutils.gradle.kts
+++ b/iutils/iutils.gradle.kts
@@ -23,7 +23,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "4.0.5"
+version = "4.0.6"
 
 project.extra["PluginName"] = "iUtils"
 project.extra["PluginDescription"] = "Illumine - Utils required for plugins to function with added automation"

--- a/iutils/src/main/java/net/runelite/client/plugins/iutils/iUtils.java
+++ b/iutils/src/main/java/net/runelite/client/plugins/iutils/iUtils.java
@@ -642,7 +642,7 @@ public class iUtils extends Plugin {
     }
 
     private void checkIdleLogout() {
-        if (!config.noAFK()) {
+        if (!config.useNoAFK()) {
             return;
         }
 

--- a/iutils/src/main/java/net/runelite/client/plugins/iutils/iUtilsConfig.java
+++ b/iutils/src/main/java/net/runelite/client/plugins/iutils/iUtilsConfig.java
@@ -121,13 +121,13 @@ public interface iUtilsConfig extends Config {
     }
 
     @ConfigItem(
-            keyName = "noAFK",
+            keyName = "useNoAFK",
             name = "Prevent AFK",
             description = "Enable to prevent logging out due to AFK.",
             position = 10
     )
-    default boolean noAFK() {
-        return true;
+    default boolean useNoAFK() {
+        return false;
     }
 
     @ConfigItem(


### PR DESCRIPTION
users should need to opt-in to use the prevent afk option