### PR TITLE
iquickeater: add ability to use invokes

### DIFF
--- a/iquickeater/src/main/java/net/runelite/client/plugins/iquickeater/iQuickEaterConfiguration.java
+++ b/iquickeater/src/main/java/net/runelite/client/plugins/iquickeater/iQuickEaterConfiguration.java
@@ -282,4 +282,15 @@ public interface iQuickEaterConfiguration extends Config {
     default boolean activateImbHeart() {
         return false;
     }
+    
+    @ConfigItem(
+            keyName = "useInvokes",
+            name = "Use Invokes",
+            description = "WARNING: This is potentially detectable. This will use items without sending any click data" +
+                    "<br>Use this if iquickeater is conflicting with another plugin",
+            position = 51
+    )
+    default boolean useInvokes() {
+        return false;
+    }
 }

--- a/iquickeater/src/main/java/net/runelite/client/plugins/iquickeater/iQuickEaterPlugin.java
+++ b/iquickeater/src/main/java/net/runelite/client/plugins/iquickeater/iQuickEaterPlugin.java
@@ -157,8 +157,12 @@ public class iQuickEaterPlugin extends Plugin {
         if (item != null) {
             targetMenu = new MenuEntry("", "", item.getId(), MenuAction.ITEM_FIRST_OPTION.getId(), item.getIndex(),
                     WidgetInfo.INVENTORY.getId(), false);
-            menu.setEntry(targetMenu);
-            mouse.delayMouseClick(item.getCanvasBounds(), calc.getRandomIntBetweenRange(25, 200));
+            if (config.useInvokes()) {
+                utils.doInvokeMsTime(targetMenu, calc.getRandomIntBetweenRange(25, 200));
+            } else {
+                menu.setEntry(targetMenu);
+                mouse.delayMouseClick(item.getCanvasBounds(), calc.getRandomIntBetweenRange(25, 200));
+            }
         }
     }
 
@@ -235,8 +239,12 @@ public class iQuickEaterPlugin extends Plugin {
                     if (playerUtils.getEquippedItems() != null && playerUtils.getEquippedItems().get(2).getId() != 11090) {
                         targetMenu = new MenuEntry("Wear", "Wear", 11090, MenuAction.ITEM_SECOND_OPTION.getId(), inventory.getWidgetItem(11090).getIndex(),
                                 WidgetInfo.INVENTORY.getId(), false);
-                        menu.setEntry(targetMenu);
-                        mouse.delayMouseClick(inventory.getWidgetItem(11090).getCanvasBounds(), calc.getRandomIntBetweenRange(25, 200));
+                        if (config.useInvokes()) {
+                            utils.doInvokeMsTime(targetMenu, calc.getRandomIntBetweenRange(25, 200));
+                        } else {
+                            menu.setEntry(targetMenu);
+                            mouse.delayMouseClick(inventory.getWidgetItem(11090).getCanvasBounds(), calc.getRandomIntBetweenRange(25, 200));
+                        }
                     }
                 } else {
                     utils.sendGameMessage("No phoenix necklaces in inventory.");


### PR DESCRIPTION
Using invokes should fix the conflict between iquickeater and other plugins. I couldn't find a way to cleanly use invokes for the stamina portion.