### PR TITLE
Replace delayMouseClick with doActionMsTime and few various fixes + improvements

### DIFF
--- a/ipowerfighter/src/main/java/net/runelite/client/plugins/ipowerfighter/iPowerFighterPlugin.java
+++ b/ipowerfighter/src/main/java/net/runelite/client/plugins/ipowerfighter/iPowerFighterPlugin.java
@@ -343,7 +343,7 @@ public class iPowerFighterPlugin extends Plugin {
                         bone.getIndex(), WidgetInfo.INVENTORY.getId(), false);
                 menu.setEntry(targetMenu);
                 mouse.handleMouseClick(bone.getCanvasBounds());
-                sleep(calc.getRandomIntBetweenRange(800, 2200));
+                sleep(calc.getRandomIntBetweenRange(1200, 1400));
             }
             iterating = false;
         });
@@ -369,8 +369,8 @@ public class iPowerFighterPlugin extends Plugin {
     private void attackNPC(NPC npc) {
         targetMenu = new MenuEntry("", "", npc.getIndex(), MenuAction.NPC_SECOND_OPTION.getId(),
                 0, 0, false);
-        menu.setEntry(targetMenu);
-        mouse.delayMouseClick(currentNPC.getConvexHull().getBounds(), sleepDelay());
+
+        utils.doActionMsTime(targetMenu, currentNPC.getConvexHull().getBounds(), sleepDelay());
         timeout = 2 + tickDelay();
     }
 
@@ -393,9 +393,9 @@ public class iPowerFighterPlugin extends Plugin {
 
     private combatType getEligibleAttackStyle() {
 
-        int attackLevel = client.getBoostedSkillLevel(Skill.ATTACK);
-        int strengthLevel = client.getBoostedSkillLevel(Skill.STRENGTH);
-        int defenceLevel = client.getBoostedSkillLevel(Skill.DEFENCE);
+        int attackLevel = client.getRealSkillLevel(Skill.ATTACK);
+        int strengthLevel = client.getRealSkillLevel(Skill.STRENGTH);
+        int defenceLevel = client.getRealSkillLevel(Skill.DEFENCE);
 
         if ((attackLevel >= config.attackLvl() && strengthLevel >= config.strengthLvl() && defenceLevel >= config.defenceLvl())) {
             return config.continueType();

--- a/ipowerskiller/src/main/java/net/runelite/client/plugins/ipowerskiller/iPowerSkillerPlugin.java
+++ b/ipowerskiller/src/main/java/net/runelite/client/plugins/ipowerskiller/iPowerSkillerPlugin.java
@@ -77,9 +77,6 @@ public class iPowerSkillerPlugin extends Plugin {
     private iUtils utils;
 
     @Inject
-    private MouseUtils mouse;
-
-    @Inject
     private PlayerUtils playerUtils;
 
     @Inject
@@ -278,8 +275,7 @@ public class iPowerSkillerPlugin extends Plugin {
         opcode = (config.customOpcode() && config.objectOpcode() ? config.objectOpcodeValue() : MenuAction.NPC_FIRST_OPTION.getId());
         if (targetNPC != null) {
             targetMenu = new MenuEntry("", "", targetNPC.getIndex(), opcode, 0, 0, false);
-            menu.setEntry(targetMenu);
-            mouse.delayMouseClick(targetNPC.getConvexHull().getBounds(), sleepDelay());
+            utils.doActionMsTime(targetMenu, targetNPC.getConvexHull().getBounds(), sleepDelay());
         } else {
             log.info("NPC is null");
         }
@@ -292,8 +288,7 @@ public class iPowerSkillerPlugin extends Plugin {
         if (targetObject != null) {
             targetMenu = new MenuEntry("", "", targetObject.getId(), opcode,
                     targetObject.getSceneMinLocation().getX(), targetObject.getSceneMinLocation().getY(), false);
-            menu.setEntry(targetMenu);
-            mouse.delayMouseClick(targetObject.getConvexHull().getBounds(), sleepDelay());
+            utils.doActionMsTime(targetMenu, targetObject.getConvexHull().getBounds(), sleepDelay());
         } else {
             log.info("Game Object is null, ids are: {}", objectIds.toString());
         }
@@ -305,8 +300,7 @@ public class iPowerSkillerPlugin extends Plugin {
         if (targetWall != null) {
             targetMenu = new MenuEntry("", "", targetWall.getId(), opcode,
                     targetWall.getLocalLocation().getSceneX(), targetWall.getLocalLocation().getSceneY(), false);
-            menu.setEntry(targetMenu);
-            mouse.delayMouseClick(targetWall.getConvexHull().getBounds(), sleepDelay());
+            utils.doActionMsTime(targetMenu, targetWall.getConvexHull().getBounds(), sleepDelay());
         } else {
             log.info("Wall Object is null, ids are: {}", objectIds.toString());
         }
@@ -337,8 +331,7 @@ public class iPowerSkillerPlugin extends Plugin {
             targetMenu = new MenuEntry("", "", bankTarget.getId(),
                     bank.getBankMenuOpcode(bankTarget.getId()), bankTarget.getSceneMinLocation().getX(),
                     bankTarget.getSceneMinLocation().getY(), false);
-            menu.setEntry(targetMenu);
-            mouse.delayMouseClick(bankTarget.getConvexHull().getBounds(), sleepDelay());
+            utils.doActionMsTime(targetMenu, bankTarget.getConvexHull().getBounds(), sleepDelay());
         } else {
             utils.sendGameMessage("Bank not found, stopping");
             startPowerSkiller = false;
@@ -641,8 +634,7 @@ public class iPowerSkillerPlugin extends Plugin {
         if (targetObject != null) {
             targetMenu = new MenuEntry("", "", targetObject.getId(), opcode,
                     targetObject.getSceneMinLocation().getX(), targetObject.getSceneMinLocation().getY(), false);
-            menu.setEntry(targetMenu);
-            mouse.delayMouseClick(targetObject.getConvexHull().getBounds(), sleepDelay());
+            utils.doActionMsTime(targetMenu, targetObject.getConvexHull().getBounds(), sleepDelay());
         } else {
             log.info("Game Object is null, ids are: {}", objectIds.toString());
         }

--- a/iquickeater/src/main/java/net/runelite/client/plugins/iquickeater/iQuickEaterPlugin.java
+++ b/iquickeater/src/main/java/net/runelite/client/plugins/iquickeater/iQuickEaterPlugin.java
@@ -157,11 +157,11 @@ public class iQuickEaterPlugin extends Plugin {
         if (item != null) {
             targetMenu = new MenuEntry("", "", item.getId(), MenuAction.ITEM_FIRST_OPTION.getId(), item.getIndex(),
                     WidgetInfo.INVENTORY.getId(), false);
+            int sleepTime = calc.getRandomIntBetweenRange(25, 200);
             if (config.useInvokes()) {
-                utils.doInvokeMsTime(targetMenu, calc.getRandomIntBetweenRange(25, 200));
+                utils.doInvokeMsTime(targetMenu, sleepTime);
             } else {
-                menu.setEntry(targetMenu);
-                mouse.delayMouseClick(item.getCanvasBounds(), calc.getRandomIntBetweenRange(25, 200));
+                utils.doActionMsTime(targetMenu, item.getCanvasBounds(), sleepTime);
             }
         }
     }

--- a/iutils/src/main/java/net/runelite/client/plugins/iutils/BankUtils.java
+++ b/iutils/src/main/java/net/runelite/client/plugins/iutils/BankUtils.java
@@ -342,11 +342,14 @@ public class BankUtils {
                         identifier = 4;
                         break;
                     default:
-                        identifier = 6;
+                        identifier = (client.getVarbitValue(3960) == amount) ? 5 : 6;
                         break;
                 }
-                menu.setEntry(new MenuEntry("", "", identifier, MenuAction.CC_OP.getId(), item.getIndex(), 786444, false));
-                mouse.delayClickRandomPointCenter(-200, 200, 50);
+                utils.doActionMsTime(
+                        new MenuEntry("", "", identifier, MenuAction.CC_OP.getId(), item.getIndex(), 786444, false),
+                        new Point(client.getCenterX() + calc.getRandomIntBetweenRange(-200, 200), client.getCenterY() + calc.getRandomIntBetweenRange(-200, 200)),
+                        50
+                );
                 if (identifier == 6) {
                     executorService.submit(() -> {
                         sleep(calc.getRandomIntBetweenRange(1000, 1500));

--- a/iutils/src/main/java/net/runelite/client/plugins/iutils/WalkUtils.java
+++ b/iutils/src/main/java/net/runelite/client/plugins/iutils/WalkUtils.java
@@ -33,6 +33,9 @@ public class WalkUtils {
     private MenuUtils menu;
 
     @Inject
+    private iUtils utils;
+
+    @Inject
     private ExecutorService executorService;
 
     public static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
@@ -63,9 +66,8 @@ public class WalkUtils {
         coordY = localPoint.getSceneY() + calc.getRandomIntBetweenRange(-Math.abs(rand), Math.abs(rand));
         log.debug("Coord values: {}, {}", coordX, coordY);
         walkAction = true;
-        menu.setEntry(new MenuEntry("Walk here", "", 0, MenuAction.WALK.getId(),
-                0, 0, false));
-        mouse.delayMouseClick(new Point(0, 0), delay);
+        utils.doActionMsTime(new MenuEntry("Walk here", "", 0, MenuAction.WALK.getId(),
+                0, 0, false), new Point(0, 0), delay);
     }
 
     public void sceneWalk(WorldPoint worldPoint, int rand, long delay) {
@@ -84,9 +86,8 @@ public class WalkUtils {
                 calc.getRandomIntBetweenRange(-Math.abs(rand), Math.abs(rand));
         log.debug("Coord values: {}, {}", coordX, coordY);
         walkAction = true;
-        menu.setEntry(new MenuEntry("Walk here", "", 0, MenuAction.WALK.getId(),
-                0, 0, false));
-        mouse.delayMouseClick(new Point(0, 0), delay);
+        utils.doActionMsTime(new MenuEntry("Walk here", "", 0, MenuAction.WALK.getId(),
+                0, 0, false), new Point(0, 0), delay);
     }
 
     /**

--- a/iutils/src/main/java/net/runelite/client/plugins/iutils/iUtils.java
+++ b/iutils/src/main/java/net/runelite/client/plugins/iutils/iUtils.java
@@ -317,7 +317,7 @@ public class iUtils extends Plugin {
     }
 
     public void doGameObjectActionClientTick(GameObject object, int menuOpcodeID, long ticksToDelay) {
-        if (object == null) {
+        if (object == null || object.getConvexHull() == null) {
             return;
         }
         Rectangle rectangle = (object.getConvexHull().getBounds() != null) ? object.getConvexHull().getBounds() :
@@ -341,7 +341,7 @@ public class iUtils extends Plugin {
     }
 
     public void doNpcActionClientTick(NPC npc, int menuOpcodeID, long ticksToDelay) {
-        if (npc == null) {
+        if (npc == null || npc.getConvexHull() == null) {
             return;
         }
         Rectangle rectangle = (npc.getConvexHull().getBounds() != null) ? npc.getConvexHull().getBounds() :
@@ -382,7 +382,7 @@ public class iUtils extends Plugin {
     }
 
     public void doGameObjectActionGameTick(GameObject object, int menuOpcodeID, long ticksToDelay) {
-        if (object == null) {
+        if (object == null || object.getConvexHull() == null) {
             return;
         }
         Rectangle rectangle = (object.getConvexHull().getBounds() != null) ? object.getConvexHull().getBounds() :
@@ -404,7 +404,7 @@ public class iUtils extends Plugin {
     }
 
     public void doNpcActionGameTick(NPC npc, int menuOpcodeID, long ticksToDelay) {
-        if (npc == null) {
+        if (npc == null || npc.getConvexHull() == null) {
             return;
         }
         Rectangle rectangle = (npc.getConvexHull().getBounds() != null) ? npc.getConvexHull().getBounds() :
@@ -444,7 +444,7 @@ public class iUtils extends Plugin {
     }
 
     public void doGameObjectActionMsTime(GameObject object, int menuOpcodeID, long timeToDelay) {
-        if (object == null) {
+        if (object == null || object.getConvexHull() == null) {
             return;
         }
         Rectangle rectangle = (object.getConvexHull().getBounds() != null) ? object.getConvexHull().getBounds() :
@@ -466,7 +466,7 @@ public class iUtils extends Plugin {
     }
 
     public void doNpcActionMsTime(NPC npc, int menuOpcodeID, long timeToDelay) {
-        if (npc == null) {
+        if (npc == null || npc.getConvexHull() == null) {
             return;
         }
         Rectangle rectangle = (npc.getConvexHull().getBounds() != null) ? npc.getConvexHull().getBounds() :
@@ -760,7 +760,7 @@ public class iUtils extends Plugin {
                         MenuAction.of(menu.modifiedOpCode), menu.entry.getParam0(), menu.entry.getParam1());
                 menu.modifiedMenu = false;
             } else {
-                System.out.println(String.format("%s, %s, %s, %s, %s, %s", menu.entry.getOption(), menu.entry.getTarget(), menu.entry.getIdentifier(), menu.entry.getOpcode(), menu.entry.getParam0(), menu.entry.getParam1()));
+//                System.out.println(String.format("%s, %s, %s, %s, %s, %s", menu.entry.getOption(), menu.entry.getTarget(), menu.entry.getIdentifier(), menu.entry.getOpcode(), menu.entry.getParam0(), menu.entry.getParam1()));
                 menuAction(event, menu.entry.getOption(), menu.entry.getTarget(), menu.entry.getIdentifier(),
                         MenuAction.of(menu.entry.getOpcode()), menu.entry.getParam0(), menu.entry.getParam1());
             }


### PR DESCRIPTION
iUtils/iQuickEater/iPowerFighter/iPowerSkiller: Replaced most occureces of `mouse.delayMouseClick` with `utils.doActionMsTime` to avoid conflicts between other plugins or user clicks.
iPowerFighter: Check for combat training style via true skill not boosted
iPowerFighter: Changed bone bury timer to improve reliability and consistency (1200,1400) from (800,2200)
iUtils: Added more checks for NPE with `getConvexHull().getBounds()`
iUtils-Bank: Added support for using the exist X amount via `client.getVarbitValue(3960)` and identifiter 5