### PR TITLE
Changed bank container ID to getter rather than static int

### DIFF
--- a/botutils/src/main/java/net/runelite/client/plugins/botutils/BotUtils.java
+++ b/botutils/src/main/java/net/runelite/client/plugins/botutils/BotUtils.java
@@ -1888,7 +1888,7 @@ public class BotUtils extends Plugin {
     public void withdrawAllItem(Widget bankItemWidget) {
         executorService.submit(() ->
         {
-            targetMenu = new MenuEntry("Withdraw-All", "", 7, MenuAction.CC_OP.getId(), bankItemWidget.getIndex(), 786444, false);
+            targetMenu = new MenuEntry("Withdraw-All", "", 7, MenuAction.CC_OP.getId(), bankItemWidget.getIndex(), WidgetInfo.BANK_ITEM_CONTAINER.getId(), false);
             clickRandomPointCenter(-200, 200);
         });
     }
@@ -1905,7 +1905,7 @@ public class BotUtils extends Plugin {
     public void withdrawItem(Widget bankItemWidget) {
         executorService.submit(() ->
         {
-            targetMenu = new MenuEntry("", "", (client.getVarbitValue(6590) == 0) ? 1 : 2, MenuAction.CC_OP.getId(), bankItemWidget.getIndex(), 786444, false);
+            targetMenu = new MenuEntry("", "", (client.getVarbitValue(6590) == 0) ? 1 : 2, MenuAction.CC_OP.getId(), bankItemWidget.getIndex(), WidgetInfo.BANK_ITEM_CONTAINER.getId(), false);
             setMenuEntry(targetMenu);
             clickRandomPointCenter(-200, 200);
         });
@@ -1937,7 +1937,7 @@ public class BotUtils extends Plugin {
                         identifier = 6;
                         break;
                 }
-                targetMenu = new MenuEntry("", "", identifier, MenuAction.CC_OP.getId(), item.getIndex(), 786444, false);
+                targetMenu = new MenuEntry("", "", identifier, MenuAction.CC_OP.getId(), item.getIndex(), WidgetInfo.BANK_ITEM_CONTAINER.getId(), false);
                 setMenuEntry(targetMenu);
                 delayClickRandomPointCenter(-200, 200, 50);
                 if (identifier == 6) {

--- a/iutils/src/main/java/net/runelite/client/plugins/iutils/BankUtils.java
+++ b/iutils/src/main/java/net/runelite/client/plugins/iutils/BankUtils.java
@@ -301,7 +301,7 @@ public class BankUtils {
     public void withdrawAllItem(Widget bankItemWidget) {
         executorService.submit(() ->
         {
-            menu.setEntry(new MenuEntry("Withdraw-All", "", 7, MenuAction.CC_OP.getId(), bankItemWidget.getIndex(), 786444, false));
+            menu.setEntry(new MenuEntry("Withdraw-All", "", 7, MenuAction.CC_OP.getId(), bankItemWidget.getIndex(), WidgetInfo.BANK_ITEM_CONTAINER.getId(), false));
             mouse.clickRandomPointCenter(-200, 200);
         });
     }
@@ -317,7 +317,7 @@ public class BankUtils {
 
     public void withdrawItem(Widget bankItemWidget) {
         MenuEntry entry = new MenuEntry("", "", (client.getVarbitValue(6590) == 0) ? 1 : 2, MenuAction.CC_OP.getId(),
-                bankItemWidget.getIndex(), 786444, false);
+                bankItemWidget.getIndex(), WidgetInfo.BANK_ITEM_CONTAINER.getId(), false);
         utils.doActionClientTick(entry, bankItemWidget.getBounds(), 0);
     }
 
@@ -348,7 +348,7 @@ public class BankUtils {
                         break;
                 }
                 utils.doActionMsTime(
-                        new MenuEntry("", "", identifier, MenuAction.CC_OP.getId(), item.getIndex(), 786444, false),
+                        new MenuEntry("", "", identifier, MenuAction.CC_OP.getId(), item.getIndex(), WidgetInfo.BANK_ITEM_CONTAINER.getId(), false),
                         new Point(client.getCenterX() + calc.getRandomIntBetweenRange(-200, 200), client.getCenterY() + calc.getRandomIntBetweenRange(-200, 200)),
                         50
                 );


### PR DESCRIPTION
Currently plugins that use this method to bank do not work. Copying the method into a plugin but changing to the bank getter will provide the right ID (786445), and should prevent this issue in future, as the correct paramID will  be returned.