### PR TITLE
Changes to iutils from oprs update

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -25,7 +25,7 @@
  */
 
 object ProjectVersions {
-    const val openosrsVersion = "4.9.6"
+    const val openosrsVersion = "4.17.0"
     const val apiVersion = "^1.0.0"
 }
 

--- a/iutils/iutils.gradle.kts
+++ b/iutils/iutils.gradle.kts
@@ -23,7 +23,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "4.7.0"
+version = "4.7.1"
 
 project.extra["PluginName"] = "iUtils"
 project.extra["PluginDescription"] = "Illumine - Utils required for plugins to function with added automation"

--- a/iutils/src/main/java/net/runelite/client/plugins/iutils/BankUtils.java
+++ b/iutils/src/main/java/net/runelite/client/plugins/iutils/BankUtils.java
@@ -67,7 +67,7 @@ public class BankUtils {
         if (!isOpen()) {
             return;
         }
-        menu.setEntry(new MenuEntry("", "", 1, MenuAction.CC_OP.getId(), 11, 786434, false)); //close bank
+        menu.setEntry(utils.setMenuEntry("", "", 1, MenuAction.CC_OP, 11, 786434, false)); //close bank
         Widget bankCloseWidget = client.getWidget(WidgetInfo.BANK_PIN_EXIT_BUTTON);
         if (bankCloseWidget != null) {
             executorService.submit(() -> mouse.handleMouseClick(bankCloseWidget.getBounds()));
@@ -195,9 +195,9 @@ public class BankUtils {
         {
             Widget depositInventoryWidget = client.getWidget(WidgetInfo.BANK_DEPOSIT_INVENTORY);
             if (isDepositBoxOpen()) {
-                menu.setEntry(new MenuEntry("", "", 1, MenuAction.CC_OP.getId(), -1, 12582916, false)); //deposit all in bank interface
+                menu.setEntry(utils.setMenuEntry("", "", 1, MenuAction.CC_OP, -1, 12582916, false)); //deposit all in bank interface
             } else {
-                menu.setEntry(new MenuEntry("", "", 1, MenuAction.CC_OP.getId(), -1, 786474, false)); //deposit all in bank interface
+                menu.setEntry(utils.setMenuEntry("", "", 1, MenuAction.CC_OP, -1, 786474, false)); //deposit all in bank interface
             }
             if ((depositInventoryWidget != null)) {
                 mouse.handleMouseClick(depositInventoryWidget.getBounds());
@@ -240,7 +240,7 @@ public class BankUtils {
             return;
         }
         boolean depositBox = isDepositBoxOpen();
-        menu.setEntry(new MenuEntry("", "", (depositBox) ? 1 : 8, MenuAction.CC_OP.getId(), item.getIndex(),
+        menu.setEntry(utils.setMenuEntry("", "", (depositBox) ? 1 : 8, MenuAction.CC_OP, item.getIndex(),
                 (depositBox) ? 12582914 : 983043, false));
         mouse.handleMouseClick(item.getCanvasBounds());
     }
@@ -286,7 +286,7 @@ public class BankUtils {
         }
         boolean depositBox = isDepositBoxOpen();
 
-        menu.setEntry(new MenuEntry("", "", (client.getVarbitValue(6590) == 0) ? 2 : 3, MenuAction.CC_OP.getId(), item.getIndex(),
+        menu.setEntry(utils.setMenuEntry("", "", (client.getVarbitValue(6590) == 0) ? 2 : 3, MenuAction.CC_OP, item.getIndex(),
                 (depositBox) ? 12582914 : 983043, false));
         mouse.delayMouseClick(item.getCanvasBounds(), calc.getRandomIntBetweenRange(0, 50));
     }
@@ -301,7 +301,7 @@ public class BankUtils {
     public void withdrawAllItem(Widget bankItemWidget) {
         executorService.submit(() ->
         {
-            menu.setEntry(new MenuEntry("Withdraw-All", "", 7, MenuAction.CC_OP.getId(), bankItemWidget.getIndex(), WidgetInfo.BANK_ITEM_CONTAINER.getId(), false));
+            menu.setEntry(utils.setMenuEntry("Withdraw-All", "", 7, MenuAction.CC_OP, bankItemWidget.getIndex(), WidgetInfo.BANK_ITEM_CONTAINER.getId(), false));
             mouse.clickRandomPointCenter(-200, 200);
         });
     }
@@ -316,7 +316,7 @@ public class BankUtils {
     }
 
     public void withdrawItem(Widget bankItemWidget) {
-        MenuEntry entry = new MenuEntry("", "", (client.getVarbitValue(6590) == 0) ? 1 : 2, MenuAction.CC_OP.getId(),
+        MenuEntry entry = utils.setMenuEntry("", "", (client.getVarbitValue(6590) == 0) ? 1 : 2, MenuAction.CC_OP,
                 bankItemWidget.getIndex(), WidgetInfo.BANK_ITEM_CONTAINER.getId(), false);
         utils.doActionClientTick(entry, bankItemWidget.getBounds(), 0);
     }
@@ -348,7 +348,7 @@ public class BankUtils {
                         break;
                 }
                 utils.doActionMsTime(
-                        new MenuEntry("", "", identifier, MenuAction.CC_OP.getId(), item.getIndex(), WidgetInfo.BANK_ITEM_CONTAINER.getId(), false),
+                        utils.setMenuEntry("", "", identifier, MenuAction.CC_OP, item.getIndex(), WidgetInfo.BANK_ITEM_CONTAINER.getId(), false),
                         new Point(client.getCenterX() + calc.getRandomIntBetweenRange(-200, 200), client.getCenterY() + calc.getRandomIntBetweenRange(-200, 200)),
                         50
                 );

--- a/iutils/src/main/java/net/runelite/client/plugins/iutils/InterfaceUtils.java
+++ b/iutils/src/main/java/net/runelite/client/plugins/iutils/InterfaceUtils.java
@@ -25,6 +25,9 @@ public class InterfaceUtils {
     @Inject
     private MenuUtils menu;
 
+    @Inject
+    private iUtils utils;
+
     /**
      * Opens the container interface using the given index.
      *
@@ -50,12 +53,13 @@ public class InterfaceUtils {
         final int INCREMENT = 4;
         int styleParam = BASE_PARAM + (index * INCREMENT);
 
-        return new MenuEntry("", "", 1, MenuAction.CC_OP.getId(), -1, styleParam, false);
+        return utils.setMenuEntry("", "", 1, MenuAction.CC_OP, -1, styleParam, false);
     }
 
     public void logout() {
         int param1 = (client.getWidget(WidgetInfo.LOGOUT_BUTTON) != null) ? 11927560 : 4522007;
-        menu.setEntry(new MenuEntry("", "", 1, MenuAction.CC_OP.getId(), -1, param1, false));
+        MenuEntry entry = utils.setMenuEntry("", "", 1, MenuAction.CC_OP, -1, param1, false);
+        menu.setEntry(entry);
         Widget logoutWidget = client.getWidget(WidgetInfo.LOGOUT_BUTTON);
         if (logoutWidget != null) {
             mouse.delayMouseClick(logoutWidget.getBounds(), calc.getRandomIntBetweenRange(5, 200));

--- a/iutils/src/main/java/net/runelite/client/plugins/iutils/InventoryUtils.java
+++ b/iutils/src/main/java/net/runelite/client/plugins/iutils/InventoryUtils.java
@@ -33,6 +33,9 @@ public class InventoryUtils {
     private BankUtils bank;
 
     @Inject
+    private iUtils utils;
+
+    @Inject
     private ExecutorService executorService;
 
     @Inject
@@ -365,7 +368,7 @@ public class InventoryUtils {
     public void dropItem(WidgetItem item) {
         assert !client.isClientThread();
 
-        menu.setEntry(new MenuEntry("", "", item.getId(), MenuAction.ITEM_FIFTH_OPTION.getId(), item.getIndex(), 9764864, false));
+        menu.setEntry(utils.setMenuEntry("", "", item.getId(), MenuAction.ITEM_FIFTH_OPTION, item.getIndex(), 9764864, false));
         mouse.click(item.getCanvasBounds());
     }
 
@@ -436,7 +439,7 @@ public class InventoryUtils {
         dropItems(inventoryItems, dropAll, minDelayBetween, maxDelayBetween);
     }
 
-    public void itemsInteract(Collection<Integer> ids, int opcode, boolean exceptItems, boolean interactAll, int minDelayBetween, int maxDelayBetween) {
+    public void itemsInteract(Collection<Integer> ids, MenuAction menuAction, boolean exceptItems, boolean interactAll, int minDelayBetween, int maxDelayBetween) {
         Collection<WidgetItem> inventoryItems = getAllItems();
         executorService.submit(() ->
         {
@@ -446,7 +449,7 @@ public class InventoryUtils {
                     if ((!exceptItems && ids.contains(item.getId()) || (exceptItems && !ids.contains(item.getId())))) {
                         log.info("interacting inventory item: {}", item.getId());
                         sleep(minDelayBetween, maxDelayBetween);
-                        menu.setEntry(new MenuEntry("", "", item.getId(), opcode, item.getIndex(), WidgetInfo.INVENTORY.getId(),
+                        menu.setEntry(utils.setMenuEntry("", "", item.getId(), menuAction, item.getIndex(), WidgetInfo.INVENTORY.getId(),
                                 true));
                         mouse.click(item.getCanvasBounds());
                         if (!interactAll) {
@@ -462,7 +465,7 @@ public class InventoryUtils {
         });
     }
 
-    public void combineItems(Collection<Integer> ids, int item1ID, int opcode, boolean exceptItems, boolean interactAll, int minDelayBetween, int maxDelayBetween) {
+    public void combineItems(Collection<Integer> ids, int item1ID, MenuAction menuAction, boolean exceptItems, boolean interactAll, int minDelayBetween, int maxDelayBetween) {
         WidgetItem item1 = getWidgetItem(item1ID);
         if (item1 == null) {
             log.info("combine item1 item not found in inventory");
@@ -477,7 +480,7 @@ public class InventoryUtils {
                     if ((!exceptItems && ids.contains(item.getId()) || (exceptItems && !ids.contains(item.getId())))) {
                         log.info("interacting inventory item: {}", item.getId());
                         sleep(minDelayBetween, maxDelayBetween);
-                        menu.setModifiedEntry(new MenuEntry("", "", item1.getId(), opcode, item1.getIndex(), WidgetInfo.INVENTORY.getId(),
+                        menu.setModifiedEntry(utils.setMenuEntry("", "", item1.getId(), menuAction, item1.getIndex(), WidgetInfo.INVENTORY.getId(),
                                 false), item.getId(), item.getIndex(), MenuAction.ITEM_USE_ON_WIDGET_ITEM.getId());
                         mouse.click(item1.getCanvasBounds());
                         if (!interactAll) {

--- a/iutils/src/main/java/net/runelite/client/plugins/iutils/ObjectUtils.java
+++ b/iutils/src/main/java/net/runelite/client/plugins/iutils/ObjectUtils.java
@@ -279,7 +279,7 @@ public class ObjectUtils {
 
         return findNearestGroundObjectMenuWithin(worldPoint, dist, menuAction);
     }
-
+/*
     @Deprecated
     @Nullable
     public List<TileItem> getTileItemsWithin(int distance) {
@@ -309,6 +309,7 @@ public class ObjectUtils {
                 .first()
                 .getGroundItems();
     }
+ */
 
     @Nullable
     public WallObject findNearestWallObject(int... ids) {

--- a/iutils/src/main/java/net/runelite/client/plugins/iutils/PlayerUtils.java
+++ b/iutils/src/main/java/net/runelite/client/plugins/iutils/PlayerUtils.java
@@ -39,6 +39,9 @@ public class PlayerUtils {
     private CalculationUtils calc;
 
     @Inject
+    private iUtils utils;
+
+    @Inject
     private ExecutorService executorService;
 
     private int nextRunEnergy;
@@ -113,7 +116,7 @@ public class PlayerUtils {
         log.info("enabling run");
         executorService.submit(() ->
         {
-            menu.setEntry(new MenuEntry("Toggle Run", "", 1, 57, -1,
+            menu.setEntry(utils.setMenuEntry("Toggle Run", "", 1, MenuAction.CC_OP, -1,
                     10485783, false));
             mouse.delayMouseClick(runOrbBounds, calc.getRandomIntBetweenRange(10, 250));
         });
@@ -138,7 +141,7 @@ public class PlayerUtils {
         WidgetItem staminaPotion = shouldStamPot(energy);
         if (staminaPotion != null) {
             log.info("using stamina potion");
-            menu.setEntry(new MenuEntry("", "", staminaPotion.getId(), MenuAction.ITEM_FIRST_OPTION.getId(),
+            menu.setEntry(utils.setMenuEntry("", "", staminaPotion.getId(), MenuAction.ITEM_FIRST_OPTION,
                     staminaPotion.getIndex(), 9764864, false));
             mouse.delayMouseClick(staminaPotion.getCanvasBounds(), calc.getRandomIntBetweenRange(5, 200));
             return true;

--- a/iutils/src/main/java/net/runelite/client/plugins/iutils/WalkUtils.java
+++ b/iutils/src/main/java/net/runelite/client/plugins/iutils/WalkUtils.java
@@ -66,8 +66,9 @@ public class WalkUtils {
         coordY = localPoint.getSceneY() + calc.getRandomIntBetweenRange(-Math.abs(rand), Math.abs(rand));
         log.debug("Coord values: {}, {}", coordX, coordY);
         walkAction = true;
-        utils.doActionMsTime(new MenuEntry("Walk here", "", 0, MenuAction.WALK.getId(),
-                0, 0, false), new Point(0, 0), delay);
+        MenuEntry entry = utils.setMenuEntry("Walk here", "", 0, MenuAction.WALK,
+                0, 0, false);
+        utils.doActionMsTime(entry, new Point(0, 0), delay);
     }
 
     public void sceneWalk(WorldPoint worldPoint, int rand, long delay) {
@@ -86,8 +87,9 @@ public class WalkUtils {
                 calc.getRandomIntBetweenRange(-Math.abs(rand), Math.abs(rand));
         log.debug("Coord values: {}, {}", coordX, coordY);
         walkAction = true;
-        utils.doActionMsTime(new MenuEntry("Walk here", "", 0, MenuAction.WALK.getId(),
-                0, 0, false), new Point(0, 0), delay);
+        MenuEntry entry = utils.setMenuEntry("Walk here", "", 0, MenuAction.WALK,
+                0, 0, false);
+        utils.doActionMsTime(entry, new Point(0, 0), delay);
     }
 
     /**

--- a/iutils/src/main/java/net/runelite/client/plugins/iutils/iUtils.java
+++ b/iutils/src/main/java/net/runelite/client/plugins/iutils/iUtils.java
@@ -27,8 +27,6 @@ import net.runelite.client.plugins.iutils.game.Game;
 import net.runelite.client.plugins.iutils.game.iObject;
 import net.runelite.client.plugins.iutils.game.iWidget;
 import net.runelite.http.api.ge.GrandExchangeClient;
-import net.runelite.http.api.osbuddy.OSBGrandExchangeClient;
-import net.runelite.http.api.osbuddy.OSBGrandExchangeResult;
 import okhttp3.OkHttpClient;
 import org.pf4j.Extension;
 
@@ -100,11 +98,6 @@ public class iUtils extends Plugin {
     ExecutorService executorService;
 
     @Inject
-    private OSBGrandExchangeClient osbGrandExchangeClient;
-
-    private OSBGrandExchangeResult osbGrandExchangeResult;
-
-    @Inject
     private ItemManager itemManager;
 
     public final static Set<TileObject> objects = new HashSet<>();
@@ -120,10 +113,6 @@ public class iUtils extends Plugin {
     private int gameTick = 0;
     int tickActions;
 
-    @Provides
-    OSBGrandExchangeClient provideOsbGrandExchangeClient(OkHttpClient okHttpClient) {
-        return new OSBGrandExchangeClient(okHttpClient);
-    }
 
     @Provides
     GrandExchangeClient provideGrandExchangeClient(OkHttpClient okHttpClient) {
@@ -563,21 +552,6 @@ public class iUtils extends Plugin {
                         .type(ChatMessageType.CONSOLE)
                         .runeLiteFormattedMessage(chatMessage)
                         .build());
-    }
-
-    public OSBGrandExchangeResult getOSBItem(int itemId) {
-        log.debug("Looking up OSB item price {}", itemId);
-
-        try {
-            final OSBGrandExchangeResult result = osbGrandExchangeClient.lookupItem(itemId);
-            if (result != null && result.getOverall_average() > 0) {
-                return result;
-            }
-        } catch (IOException e) {
-            log.debug("Error getting price of item {}", itemId, e);
-        }
-
-        return null;
     }
 
     public ItemComposition getCompositionItem(int itemId) {

--- a/iutils/src/main/java/net/runelite/client/plugins/iutils/iUtils.java
+++ b/iutils/src/main/java/net/runelite/client/plugins/iutils/iUtils.java
@@ -44,683 +44,681 @@ import java.util.stream.Collectors;
  */
 @Extension
 @PluginDescriptor(
-        name = "iUtils",
-        description = "Illumine plugin utilities"
+		name = "iUtils",
+		description = "Illumine plugin utilities"
 )
 @Slf4j
 @SuppressWarnings("unused")
 @Singleton
 public class iUtils extends Plugin {
 
-    @Inject
-    public Game game;
+	@Inject
+	public Game game;
 
-    @Inject
-    private Client client;
+	@Inject
+	private Client client;
 
-    @Inject
-    private ClientThread clientThread;
+	@Inject
+	private ClientThread clientThread;
 
-    @Inject
-    public iUtilsConfig config;
+	@Inject
+	public iUtilsConfig config;
 
-    @Inject
-    private MouseUtils mouse;
+	@Inject
+	private MouseUtils mouse;
 
-    @Inject
-    private ActionQueue action;
-
-    @Inject
-    private MenuUtils menu;
+	@Inject
+	private ActionQueue action;
+
+	@Inject
+	private MenuUtils menu;
 
-    @Inject
-    private WalkUtils walk;
-
-    @Inject
-    private CalculationUtils calc;
-
-    @Inject
-    private InterfaceUtils interfaceUtils;
-
-    @Inject
-    private KeyboardUtils keyboard;
-
-    @Inject
-    private ChatMessageManager chatMessageManager;
-
-    @Inject
-    private ObjectUtils objectUtils;
-
-    @Inject
-    private BankUtils bankUtils;
-
-    @Inject
-    ExecutorService executorService;
-
-    @Inject
-    private ItemManager itemManager;
-
-    public final static Set<TileObject> objects = new HashSet<>();
-    public final static Set<TileItem> tileItems = new HashSet<>();
-    public final static Set<NPC> npcs = new HashSet<>();
-    public final static List<iWidget> bankitems = new ArrayList<>();
-    public final static List<iWidget> bankInventoryitems = new ArrayList<>();
-
-    public boolean randomEvent;
-    public static boolean iterating;
-    private final List<ActionQueue.DelayedAction> delayedActions = new ArrayList<>();
-    private int clientTick = 0;
-    private int gameTick = 0;
-    int tickActions;
-
-
-    @Provides
-    GrandExchangeClient provideGrandExchangeClient(OkHttpClient okHttpClient) {
-        return new GrandExchangeClient(okHttpClient);
-    }
-
-    @Provides
-    iUtilsConfig provideConfig(ConfigManager configManager) {
-        return configManager.getConfig(iUtilsConfig.class);
-    }
-
-    @Override
-    protected void startUp() {
-    }
-
-    @Override
-    protected void shutDown() {
-
-    }
-
-    @Subscribe
-    private void onConfigButtonPressed(ConfigButtonClicked configButtonClicked) {
-        if (!configButtonClicked.getGroup().equalsIgnoreCase("iUtils")) {
-            return;
-        }
-        log.info("button {} pressed!", configButtonClicked.getKey());
-        if (configButtonClicked.getKey().equals("startButton")) {
-
-        }
-    }
-
-    @Subscribe
-    public void onGameStateChanged(GameStateChanged gameStateChanged) {
-        if (gameStateChanged.getGameState() != GameState.LOGGED_IN && gameStateChanged.getGameState() != GameState.CONNECTION_LOST) {
-            objects.clear();
-            npcs.clear();
-            tileItems.clear();
-            bankitems.clear();
-            bankInventoryitems.clear();
-        }
-    }
-
-    @Subscribe
-    public void onWallObjectSpawned(WallObjectSpawned event) {
-        objects.add(event.getWallObject());
-    }
-
-    @Subscribe
-    public void onWallObjectChanged(WallObjectChanged event) {
-        objects.remove(event.getPrevious());
-        objects.add(event.getWallObject());
-    }
-
-    @Subscribe
-    public void onWallObjectDespawned(WallObjectDespawned event) {
-        objects.remove(event.getWallObject());
-    }
-
-    @Subscribe
-    public void onGameObjectSpawned(GameObjectSpawned event) {
-        objects.add(event.getGameObject());
-    }
-
-    @Subscribe
-    public void onGameObjectDespawned(GameObjectDespawned event) {
-        objects.remove(event.getGameObject());
-    }
-
-    @Subscribe
-    public void onDecorativeObjectSpawned(DecorativeObjectSpawned event) {
-        objects.add(event.getDecorativeObject());
-    }
-
-    @Subscribe
-    public void onDecorativeObjectDespawned(DecorativeObjectDespawned event) {
-        objects.remove(event.getDecorativeObject());
-    }
-
-    @Subscribe
-    public void onGroundObjectSpawned(GroundObjectSpawned event) {
-        objects.add(event.getGroundObject());
-    }
-
-    @Subscribe
-    public void onGroundObjectDespawned(GroundObjectDespawned event) {
-        objects.remove(event.getGroundObject());
-    }
-
-    @Subscribe
-    private void onItemSpawned(ItemSpawned event) {
-        tileItems.add(event.getItem());
-    }
-
-    @Subscribe
-    private void onItemDespawned(ItemDespawned event) {
-        tileItems.remove(event.getItem());
-    }
-
-    @Subscribe
-    public void npcSpawned(NpcSpawned event) {
-        npcs.add(event.getNpc());
-    }
-
-    @Subscribe
-    public void npcDespawned(NpcDespawned event) {
-        npcs.remove(event.getNpc());
-    }
-
-    @Subscribe
-    private void onItemContainerChanged(ItemContainerChanged event) {
-        if (client.getWidget(WidgetInfo.BANK_INVENTORY_ITEMS_CONTAINER) != null && bankUtils.isOpen() &&
-                event.getContainerId() == InventoryID.INVENTORY.getId()) {
-            loadBankInventoryItems();
-        }
-
-        if (bankUtils.isOpen() && event.getContainerId() == InventoryID.BANK.getId()) {
-            loadBankItems();
-        }
-    }
-
-    private void loadBankInventoryItems() {
-        bankInventoryitems.clear();
-        for (Widget item : client.getWidget(WidgetInfo.BANK_INVENTORY_ITEMS_CONTAINER).getDynamicChildren()) {
-            if (item == null || item.getItemId() == 6512 || item.getItemId() == -1 || item.isHidden()) {
-                continue;
-            }
-            bankInventoryitems.add(new iWidget(game, item));
-        }
-    }
-
-    private void loadBankItems() {
-        bankitems.clear();
-        for (Widget item : client.getWidget(WidgetInfo.BANK_ITEM_CONTAINER).getDynamicChildren()) {
-            if (item == null || item.getItemId() == 6512 || item.getItemId() == -1 || item.isHidden()) {
-                continue;
-            }
-            bankitems.add(new iWidget(game, item));
-        }
-    }
-
-    @Subscribe
-    private void onWidgetLoaded(WidgetLoaded event) {
-        if (event.getGroupId() == 12) {
-            loadBankItems();
-        }
-
-        if (event.getGroupId() == 15) {
-            loadBankInventoryItems();
-        }
-    }
-
-    @Subscribe
-    private void onWidgetClosed(WidgetClosed event) {
-        if (event.getGroupId() == 12) {
-            bankitems.clear();
-        }
-
-        if (event.getGroupId() == 15) {
-            bankInventoryitems.clear();
-        }
-    }
-
-    public void doTestActionGameTick(Runnable runnable, Point point, long ticksToDelay) {
-
-        action.delayGameTicks(ticksToDelay, runnable);
-    }
-
-    //Use with caution, does not pair with mouse click and is potentially detectable
-    public void doInvokeClientTick(MenuEntry entry, long ticksToDelay) {
-        Runnable runnable = () -> client.invokeMenuAction(entry.getOption(), entry.getTarget(), entry.getIdentifier(),
-                entry.getOpcode(), entry.getParam0(), entry.getParam1());
-        action.delayClientTicks(ticksToDelay, runnable);
-    }
-
-    public void doActionClientTick(MenuEntry entry, Rectangle rect, long ticksToDelay) {
-        Point point = mouse.getClickPoint(rect);
-        doActionClientTick(entry, point, ticksToDelay);
-    }
-
-    public void doActionClientTick(MenuEntry entry, Point point, long ticksToDelay) {
-        Runnable runnable = () -> {
-            menu.setEntry(entry);
-            mouse.handleMouseClick(point);
-        };
-
-        action.delayClientTicks(ticksToDelay, runnable);
-    }
-
-    public void doGameObjectActionClientTick(GameObject object, int menuOpcodeID, long ticksToDelay) {
-        if (object == null || object.getConvexHull() == null) {
-            return;
-        }
-        Rectangle rectangle = (object.getConvexHull().getBounds() != null) ? object.getConvexHull().getBounds() :
-                new Rectangle(client.getCenterX() - 50, client.getCenterY() - 50, 100, 100);
-        MenuEntry entry = new MenuEntry("", "", object.getId(), menuOpcodeID, object.getSceneMinLocation().getX(),
-                object.getSceneMinLocation().getY(), false);
-        doActionClientTick(entry, rectangle, ticksToDelay);
-        iObject test;
-
-    }
-
-    public void doTileObjectActionClientTick(TileObject object, int menuOpcodeID, long ticksToDelay) {
-        if (object == null) {
-            return;
-        }
-        Rectangle rectangle = (object.getCanvasTilePoly().getBounds() != null) ? object.getCanvasTilePoly().getBounds() :
-                new Rectangle(client.getCenterX() - 50, client.getCenterY() - 50, 100, 100);
-        MenuEntry entry = new MenuEntry("", "", object.getId(), menuOpcodeID, object.getLocalLocation().getSceneX(),
-                object.getLocalLocation().getSceneY(), false);
-        doActionClientTick(entry, rectangle, ticksToDelay);
-    }
-
-    public void doNpcActionClientTick(NPC npc, int menuOpcodeID, long ticksToDelay) {
-        if (npc == null || npc.getConvexHull() == null) {
-            return;
-        }
-        Rectangle rectangle = (npc.getConvexHull().getBounds() != null) ? npc.getConvexHull().getBounds() :
-                new Rectangle(client.getCenterX() - 50, client.getCenterY() - 50, 100, 100);
-        MenuEntry entry = new MenuEntry("", "", npc.getIndex(), menuOpcodeID, 0, 0, false);
-        doActionClientTick(entry, rectangle, ticksToDelay);
-    }
-
-    public void doItemActionClientTick(WidgetItem item, int menuOpcodeID, int menuParam1ID, long ticksToDelay) {
-        if (item == null) {
-            return;
-        }
-        MenuEntry entry = new MenuEntry("", "", item.getId(), menuOpcodeID,
-                item.getIndex(), menuParam1ID, true);
-        doActionClientTick(entry, item.getCanvasBounds().getBounds(), ticksToDelay);
-    }
-
-    //Use with caution, does not pair with mouse click and is potentially detectable
-    public void doInvokeGameTick(MenuEntry entry, long ticksToDelay) {
-        Runnable runnable = () -> client.invokeMenuAction(entry.getOption(), entry.getTarget(), entry.getIdentifier(),
-                entry.getOpcode(), entry.getParam0(), entry.getParam1());
-        action.delayGameTicks(ticksToDelay, runnable);
-    }
-
-    public void doActionGameTick(MenuEntry entry, Rectangle rect, long ticksToDelay) {
-        Point point = mouse.getClickPoint(rect);
-        doActionGameTick(entry, point, ticksToDelay);
-    }
-
-    public void doActionGameTick(MenuEntry entry, Point point, long ticksToDelay) {
-
-        Runnable runnable = () -> {
-            menu.setEntry(entry);
-            mouse.handleMouseClick(point);
-        };
-
-        action.delayGameTicks(ticksToDelay, runnable);
-    }
-
-    public void doGameObjectActionGameTick(GameObject object, int menuOpcodeID, long ticksToDelay) {
-        if (object == null || object.getConvexHull() == null) {
-            return;
-        }
-        Rectangle rectangle = (object.getConvexHull().getBounds() != null) ? object.getConvexHull().getBounds() :
-                new Rectangle(client.getCenterX() - 50, client.getCenterY() - 50, 100, 100);
-        MenuEntry entry = new MenuEntry("", "", object.getId(), menuOpcodeID, object.getSceneMinLocation().getX(),
-                object.getSceneMinLocation().getY(), false);
-        doActionGameTick(entry, rectangle, ticksToDelay);
-    }
-
-    public void doTileObjectActionGameTick(TileObject object, int menuOpcodeID, long ticksToDelay) {
-        if (object == null) {
-            return;
-        }
-        Rectangle rectangle = (object.getCanvasTilePoly().getBounds() != null) ? object.getCanvasTilePoly().getBounds() :
-                new Rectangle(client.getCenterX() - 50, client.getCenterY() - 50, 100, 100);
-        MenuEntry entry = new MenuEntry("", "", object.getId(), menuOpcodeID, object.getLocalLocation().getSceneX(),
-                object.getLocalLocation().getSceneY(), false);
-        doActionGameTick(entry, rectangle, ticksToDelay);
-    }
-
-    public void doNpcActionGameTick(NPC npc, int menuOpcodeID, long ticksToDelay) {
-        if (npc == null || npc.getConvexHull() == null) {
-            return;
-        }
-        Rectangle rectangle = (npc.getConvexHull().getBounds() != null) ? npc.getConvexHull().getBounds() :
-                new Rectangle(client.getCenterX() - 50, client.getCenterY() - 50, 100, 100);
-        MenuEntry entry = new MenuEntry("", "", npc.getIndex(), menuOpcodeID, 0, 0, false);
-        doActionGameTick(entry, rectangle, ticksToDelay);
-    }
-
-    public void doItemActionGameTick(WidgetItem item, int menuOpcodeID, int menuParam1ID, long ticksToDelay) {
-        if (item == null) {
-            return;
-        }
-        MenuEntry entry = new MenuEntry("", "", item.getId(), menuOpcodeID,
-                item.getIndex(), menuParam1ID, true);
-        doActionGameTick(entry, item.getCanvasBounds().getBounds(), ticksToDelay);
-    }
-
-    //Use with caution, does not pair with mouse click and is potentially detectable
-    public void doInvokeMsTime(MenuEntry entry, long timeToDelay) {
-        Runnable runnable = () -> client.invokeMenuAction(entry.getOption(), entry.getTarget(), entry.getIdentifier(),
-                entry.getOpcode(), entry.getParam0(), entry.getParam1());
-        action.delayTime(timeToDelay, runnable);
-    }
-
-    public void doActionMsTime(MenuEntry entry, Rectangle rect, long timeToDelay) {
-        Point point = mouse.getClickPoint(rect);
-        doActionMsTime(entry, point, timeToDelay);
-    }
-
-    public void doActionMsTime(MenuEntry entry, Point point, long timeToDelay) {
-        Runnable runnable = () -> {
-            menu.setEntry(entry);
-            mouse.handleMouseClick(point);
-        };
-
-        action.delayTime(timeToDelay, runnable);
-    }
-
-    public void doGameObjectActionMsTime(GameObject object, int menuOpcodeID, long timeToDelay) {
-        if (object == null || object.getConvexHull() == null) {
-            return;
-        }
-        Rectangle rectangle = (object.getConvexHull().getBounds() != null) ? object.getConvexHull().getBounds() :
-                new Rectangle(client.getCenterX() - 50, client.getCenterY() - 50, 100, 100);
-        MenuEntry entry = new MenuEntry("", "", object.getId(), menuOpcodeID, object.getSceneMinLocation().getX(),
-                object.getSceneMinLocation().getY(), false);
-        doActionMsTime(entry, rectangle, timeToDelay);
-    }
-
-    public void doTileObjectActionMsTime(TileObject object, int menuOpcodeID, long timeToDelay) {
-        if (object == null) {
-            return;
-        }
-        Rectangle rectangle = (object.getCanvasTilePoly().getBounds() != null) ? object.getCanvasTilePoly().getBounds() :
-                new Rectangle(client.getCenterX() - 50, client.getCenterY() - 50, 100, 100);
-        MenuEntry entry = new MenuEntry("", "", object.getId(), menuOpcodeID, object.getLocalLocation().getSceneX(),
-                object.getLocalLocation().getSceneY(), false);
-        doActionMsTime(entry, rectangle, timeToDelay);
-    }
-
-    public void doNpcActionMsTime(NPC npc, int menuOpcodeID, long timeToDelay) {
-        if (npc == null || npc.getConvexHull() == null) {
-            return;
-        }
-        Rectangle rectangle = (npc.getConvexHull().getBounds() != null) ? npc.getConvexHull().getBounds() :
-                new Rectangle(client.getCenterX() - 50, client.getCenterY() - 50, 100, 100);
-        MenuEntry entry = new MenuEntry("", "", npc.getIndex(), menuOpcodeID, 0, 0, false);
-        doActionMsTime(entry, rectangle, timeToDelay);
-    }
-
-    public void doItemActionMsTime(WidgetItem item, int menuOpcodeID, int menuParam1ID, long timeToDelay) {
-        if (item == null) {
-            return;
-        }
-        MenuEntry entry = new MenuEntry("", "", item.getId(), menuOpcodeID,
-                item.getIndex(), menuParam1ID, true);
-        doActionMsTime(entry, item.getCanvasBounds().getBounds(), timeToDelay);
-    }
-
-    public void doModifiedActionGameTick(MenuEntry entry, int modifiedID, int modifiedIndex, int modifiedOpcode, Rectangle rect, long ticksToDelay) {
-        Point point = mouse.getClickPoint(rect);
-        doModifiedActionGameTick(entry, modifiedID, modifiedIndex, modifiedOpcode, point, ticksToDelay);
-    }
-
-    public void doModifiedActionGameTick(MenuEntry entry, int modifiedID, int modifiedIndex, int modifiedOpcode, Point point, long ticksToDelay) {
-        Runnable runnable = () -> {
-            menu.setModifiedEntry(entry, modifiedID, modifiedIndex, modifiedOpcode);
-            mouse.handleMouseClick(point);
-        };
-
-        action.delayGameTicks(ticksToDelay, runnable);
-    }
-
-    //Use with caution, does not pair with mouse click and is potentially detectable
-    public void doModifiedInvokeGameTick(MenuEntry entry, int modifiedID, int modifiedIndex, int modifiedOpcode, long ticksToDelay) {
-        Runnable runnable = () -> {
-            client.setSelectedItemWidget(WidgetInfo.INVENTORY.getId());
-            client.setSelectedItemSlot(modifiedIndex);
-            client.setSelectedItemID(modifiedID);
-            client.invokeMenuAction(entry.getOption(), entry.getTarget(), entry.getIdentifier(),
-                    modifiedOpcode, entry.getParam0(), entry.getParam1());
-        };
-
-        action.delayGameTicks(ticksToDelay, runnable);
-    }
-
-    public void doModifiedActionMsTime(MenuEntry entry, int modifiedID, int modifiedIndex, int modifiedOpcode, Rectangle rect, long timeToDelay) {
-        Point point = mouse.getClickPoint(rect);
-        doModifiedActionMsTime(entry, modifiedID, modifiedIndex, modifiedOpcode, point, timeToDelay);
-    }
-
-    public void doModifiedActionMsTime(MenuEntry entry, int modifiedID, int modifiedIndex, int modifiedOpcode, Point point, long timeToDelay) {
-        Runnable runnable = () -> {
-            menu.setModifiedEntry(entry, modifiedID, modifiedIndex, modifiedOpcode);
-            mouse.handleMouseClick(point);
-        };
-
-        action.delayTime(timeToDelay, runnable);
-    }
-
-    //Use with caution, does not pair with mouse click and is potentially detectable
-    public void doModifiedInvokeMsTime(MenuEntry entry, int modifiedID, int modifiedIndex, int modifiedOpcode, long timeToDelay) {
-        Runnable runnable = () -> {
-            client.setSelectedItemWidget(WidgetInfo.INVENTORY.getId());
-            client.setSelectedItemSlot(modifiedIndex);
-            client.setSelectedItemID(modifiedID);
-            client.invokeMenuAction(entry.getOption(), entry.getTarget(), entry.getIdentifier(),
-                    modifiedOpcode, entry.getParam0(), entry.getParam1());
-        };
-
-        action.delayTime(timeToDelay, runnable);
-    }
-
-    public void oneClickCastSpell(WidgetInfo spellWidget, MenuEntry targetMenu, long sleepLength) {
-        menu.setEntry(targetMenu, true);
-        mouse.delayMouseClick(new Rectangle(0, 0, 100, 100), sleepLength);
-        menu.setSelectedSpell(spellWidget);
-        mouse.delayMouseClick(new Rectangle(0, 0, 100, 100), calc.getRandomIntBetweenRange(20, 60));
-    }
-
-    public void oneClickCastSpell(WidgetInfo spellWidget, MenuEntry targetMenu, Rectangle targetBounds, long sleepLength) {
-        menu.setEntry(targetMenu, false);
-        menu.setSelectedSpell(spellWidget);
-        mouse.delayMouseClick(targetBounds, sleepLength);
-    }
-
-    public void setCombatStyle(int index) {
-        MenuEntry entry = interfaceUtils.getAttackStyleMenuEntry(index);
-        doActionClientTick(entry, new Point(0, 0), 0);
-    }
-
-    public void sendGameMessage(String message) {
-        String chatMessage = new ChatMessageBuilder()
-                .append(ChatColorType.HIGHLIGHT)
-                .append(message)
-                .build();
-
-        chatMessageManager
-                .queue(QueuedMessage.builder()
-                        .type(ChatMessageType.CONSOLE)
-                        .runeLiteFormattedMessage(chatMessage)
-                        .build());
-    }
-
-    public ItemComposition getCompositionItem(int itemId) {
-        log.debug("Looking up CompositionItem: {}", itemId);
-
-        return itemManager.getItemComposition(itemId);
-    }
-
-    public int getItemPrice(int itemId, boolean useWikiPrice) {
-        log.debug("Looking up price for Item: {}", itemId);
-
-        return itemManager.getItemPriceWithSource(itemId, useWikiPrice);
-    }
-
-    //Ganom's
-    public int[] stringToIntArray(String string) {
-        return Arrays.stream(string.split(",")).map(String::trim).mapToInt(Integer::parseInt).toArray();
-    }
-
-    public List<Integer> stringToIntList(String string) {
-        return (string == null || string.trim().equals("")) ? List.of(0) :
-                Arrays.stream(string.split(",")).map(String::trim).map(Integer::parseInt).collect(Collectors.toList());
-    }
-
-    public boolean pointOnScreen(Point check) {
-        int x = check.getX(), y = check.getY();
-        return x > client.getViewportXOffset() && x < client.getViewportWidth()
-                && y > client.getViewportYOffset() && y < client.getViewportHeight();
-    }
-
-
-    /**
-     * RANDOM EVENT FUNCTIONS
-     */
-    public void setRandomEvent(boolean random) {
-        randomEvent = random;
-    }
-
-    public boolean getRandomEvent() {
-        return randomEvent;
-    }
-
-    /**
-     * Pauses execution for a random amount of time between two values.
-     *
-     * @param minSleep The minimum time to sleep.
-     * @param maxSleep The maximum time to sleep.
-     * @see #sleep(int)
-     */
-
-    public static void sleep(int minSleep, int maxSleep) {
-        sleep(CalculationUtils.random(minSleep, maxSleep));
-    }
-
-    /**
-     * Pauses execution for a given number of milliseconds.
-     *
-     * @param toSleep The time to sleep in milliseconds.
-     */
-    public static void sleep(int toSleep) {
-        try {
-            long start = System.currentTimeMillis();
-            Thread.sleep(toSleep);
-
-            // Guarantee minimum sleep
-            long now;
-            while (start + toSleep > (now = System.currentTimeMillis())) {
-                Thread.sleep(start + toSleep - now);
-            }
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
-    }
-
-    public static void sleep(long toSleep) {
-        try {
-            long start = System.currentTimeMillis();
-            Thread.sleep(toSleep);
-
-            // Guarantee minimum sleep
-            long now;
-            while (start + toSleep > (now = System.currentTimeMillis())) {
-                Thread.sleep(start + toSleep - now);
-            }
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
-    }
-
-    @Subscribe
-    public void onClientTick(ClientTick event) {
-        action.onClientTick(event);
-    }
-
-    @Subscribe
-    private void onGameTick(GameTick event) {
-        tickActions = 0;
-        action.onGameTick(event);
-    }
-
-    @Subscribe
-    private void onMenuEntryAdded(MenuEntryAdded event) {
-        if (event.getOpcode() == MenuAction.CC_OP.getId() && (event.getParam1() == WidgetInfo.WORLD_SWITCHER_LIST.getId() ||
-                event.getParam1() == 11927560 || event.getParam1() == 4522007 || event.getParam1() == 24772686)) {
-            return;
-        }
-        if (menu.entry != null) {
-            client.setLeftClickMenuEntry(menu.entry);
-            if (menu.modifiedMenu) {
-                event.setModified();
-            }
-        }
-    }
-
-    @Subscribe
-    private void onMenuOptionClicked(MenuOptionClicked event) {
-        if (event.getMenuAction() == MenuAction.CC_OP && (event.getWidgetId() == WidgetInfo.WORLD_SWITCHER_LIST.getId() ||
-                event.getWidgetId() == 11927560 || event.getWidgetId() == 4522007 || event.getWidgetId() == 24772686)) {
-            //Either logging out or world-hopping which is handled by 3rd party plugins so let them have priority
-            log.info("Received world-hop/login related click. Giving them priority");
-            menu.entry = null;
-            return;
-        }
-        if (menu.entry != null) {
-            tickActions++;
-            log.debug("Actions this game tick: {}", tickActions);
-            if (menu.consumeClick) {
-                event.consume();
-                log.info("Consuming a click and not sending anything else");
-                menu.consumeClick = false;
-                return;
-            }
-            if (menu.entry.getOption().equals("Walk here")) {
-                event.consume();
-                log.debug("Walk action: {} {}", walk.coordX, walk.coordY);
-                walk.walkTile(walk.coordX, walk.coordY);
-                walk.walkAction = false;
-                menu.entry = null;
-                return;
-            }
-            if (menu.modifiedMenu) {
-                client.setSelectedItemWidget(WidgetInfo.INVENTORY.getId());
-                client.setSelectedItemSlot(menu.modifiedItemIndex);
-                client.setSelectedItemID(menu.modifiedItemID);
-                log.debug("doing a Modified MOC, mod ID: {}, mod index: {}, param1: {}", menu.modifiedItemID,
-                        menu.modifiedItemIndex, menu.entry.getParam1());
-                menuAction(event, menu.entry.getOption(), menu.entry.getTarget(), menu.entry.getIdentifier(),
-                        MenuAction.of(menu.modifiedOpCode), menu.entry.getParam0(), menu.entry.getParam1());
-                menu.modifiedMenu = false;
-            } else {
+	@Inject
+	private WalkUtils walk;
+
+	@Inject
+	private CalculationUtils calc;
+
+	@Inject
+	private InterfaceUtils interfaceUtils;
+
+	@Inject
+	private KeyboardUtils keyboard;
+
+	@Inject
+	private ChatMessageManager chatMessageManager;
+
+	@Inject
+	private ObjectUtils objectUtils;
+
+	@Inject
+	private BankUtils bankUtils;
+
+	@Inject
+	ExecutorService executorService;
+
+	@Inject
+	private ItemManager itemManager;
+
+	public final static Set<TileObject> objects = new HashSet<>();
+	public final static Set<TileItem> tileItems = new HashSet<>();
+	public final static Set<NPC> npcs = new HashSet<>();
+	public final static List<iWidget> bankitems = new ArrayList<>();
+	public final static List<iWidget> bankInventoryitems = new ArrayList<>();
+
+	public boolean randomEvent;
+	public static boolean iterating;
+	private final List<ActionQueue.DelayedAction> delayedActions = new ArrayList<>();
+	private int clientTick = 0;
+	private int gameTick = 0;
+	int tickActions;
+
+
+	@Provides
+	GrandExchangeClient provideGrandExchangeClient(OkHttpClient okHttpClient) {
+		return new GrandExchangeClient(okHttpClient);
+	}
+
+	@Provides
+	iUtilsConfig provideConfig(ConfigManager configManager) {
+		return configManager.getConfig(iUtilsConfig.class);
+	}
+
+	@Override
+	protected void startUp() {
+	}
+
+	@Override
+	protected void shutDown() {
+
+	}
+
+	@Subscribe
+	private void onConfigButtonPressed(ConfigButtonClicked configButtonClicked) {
+		if (!configButtonClicked.getGroup().equalsIgnoreCase("iUtils")) {
+			return;
+		}
+		log.info("button {} pressed!", configButtonClicked.getKey());
+		if (configButtonClicked.getKey().equals("startButton")) {
+
+		}
+	}
+
+	@Subscribe
+	public void onGameStateChanged(GameStateChanged gameStateChanged) {
+		if (gameStateChanged.getGameState() != GameState.LOGGED_IN && gameStateChanged.getGameState() != GameState.CONNECTION_LOST) {
+			objects.clear();
+			npcs.clear();
+			tileItems.clear();
+			bankitems.clear();
+			bankInventoryitems.clear();
+		}
+	}
+
+	@Subscribe
+	public void onWallObjectSpawned(WallObjectSpawned event) {
+		objects.add(event.getWallObject());
+	}
+
+	@Subscribe
+	public void onWallObjectChanged(WallObjectChanged event) {
+		objects.remove(event.getPrevious());
+		objects.add(event.getWallObject());
+	}
+
+	@Subscribe
+	public void onWallObjectDespawned(WallObjectDespawned event) {
+		objects.remove(event.getWallObject());
+	}
+
+	@Subscribe
+	public void onGameObjectSpawned(GameObjectSpawned event) {
+		objects.add(event.getGameObject());
+	}
+
+	@Subscribe
+	public void onGameObjectDespawned(GameObjectDespawned event) {
+		objects.remove(event.getGameObject());
+	}
+
+	@Subscribe
+	public void onDecorativeObjectSpawned(DecorativeObjectSpawned event) {
+		objects.add(event.getDecorativeObject());
+	}
+
+	@Subscribe
+	public void onDecorativeObjectDespawned(DecorativeObjectDespawned event) {
+		objects.remove(event.getDecorativeObject());
+	}
+
+	@Subscribe
+	public void onGroundObjectSpawned(GroundObjectSpawned event) {
+		objects.add(event.getGroundObject());
+	}
+
+	@Subscribe
+	public void onGroundObjectDespawned(GroundObjectDespawned event) {
+		objects.remove(event.getGroundObject());
+	}
+
+	@Subscribe
+	private void onItemSpawned(ItemSpawned event) {
+		tileItems.add(event.getItem());
+	}
+
+	@Subscribe
+	private void onItemDespawned(ItemDespawned event) {
+		tileItems.remove(event.getItem());
+	}
+
+	@Subscribe
+	public void npcSpawned(NpcSpawned event) {
+		npcs.add(event.getNpc());
+	}
+
+	@Subscribe
+	public void npcDespawned(NpcDespawned event) {
+		npcs.remove(event.getNpc());
+	}
+
+	@Subscribe
+	private void onItemContainerChanged(ItemContainerChanged event) {
+		if (client.getWidget(WidgetInfo.BANK_INVENTORY_ITEMS_CONTAINER) != null && bankUtils.isOpen() &&
+				event.getContainerId() == InventoryID.INVENTORY.getId()) {
+			loadBankInventoryItems();
+		}
+
+		if (bankUtils.isOpen() && event.getContainerId() == InventoryID.BANK.getId()) {
+			loadBankItems();
+		}
+	}
+
+	private void loadBankInventoryItems() {
+		bankInventoryitems.clear();
+		for (Widget item : client.getWidget(WidgetInfo.BANK_INVENTORY_ITEMS_CONTAINER).getDynamicChildren()) {
+			if (item == null || item.getItemId() == 6512 || item.getItemId() == -1 || item.isHidden()) {
+				continue;
+			}
+			bankInventoryitems.add(new iWidget(game, item));
+		}
+	}
+
+	private void loadBankItems() {
+		bankitems.clear();
+		for (Widget item : client.getWidget(WidgetInfo.BANK_ITEM_CONTAINER).getDynamicChildren()) {
+			if (item == null || item.getItemId() == 6512 || item.getItemId() == -1 || item.isHidden()) {
+				continue;
+			}
+			bankitems.add(new iWidget(game, item));
+		}
+	}
+
+	@Subscribe
+	private void onWidgetLoaded(WidgetLoaded event) {
+		if (event.getGroupId() == 12) {
+			loadBankItems();
+		}
+
+		if (event.getGroupId() == 15) {
+			loadBankInventoryItems();
+		}
+	}
+
+	@Subscribe
+	private void onWidgetClosed(WidgetClosed event) {
+		if (event.getGroupId() == 12) {
+			bankitems.clear();
+		}
+
+		if (event.getGroupId() == 15) {
+			bankInventoryitems.clear();
+		}
+	}
+
+	public void doTestActionGameTick(Runnable runnable, Point point, long ticksToDelay) {
+
+		action.delayGameTicks(ticksToDelay, runnable);
+	}
+
+	//Use with caution, does not pair with mouse click and is potentially detectable
+	public void doInvokeClientTick(MenuEntry entry, long ticksToDelay) {
+		Runnable runnable = () -> client.invokeMenuAction(entry.getOption(), entry.getTarget(), entry.getIdentifier(),
+				entry.getOpcode(), entry.getParam0(), entry.getParam1());
+		action.delayClientTicks(ticksToDelay, runnable);
+	}
+
+	public void doActionClientTick(MenuEntry entry, Rectangle rect, long ticksToDelay) {
+		Point point = mouse.getClickPoint(rect);
+		doActionClientTick(entry, point, ticksToDelay);
+	}
+
+	public void doActionClientTick(MenuEntry entry, Point point, long ticksToDelay) {
+		Runnable runnable = () -> {
+			menu.setEntry(entry);
+			mouse.handleMouseClick(point);
+		};
+
+		action.delayClientTicks(ticksToDelay, runnable);
+	}
+
+	public void doGameObjectActionClientTick(GameObject object, MenuAction menuAction, long ticksToDelay) {
+		if (object == null || object.getConvexHull() == null) {
+			return;
+		}
+		Rectangle rectangle = (object.getConvexHull().getBounds() != null) ? object.getConvexHull().getBounds() :
+				new Rectangle(client.getCenterX() - 50, client.getCenterY() - 50, 100, 100);
+		MenuEntry entry = setMenuEntry("", "", object.getId(), menuAction, object.getSceneMinLocation().getX(), object.getSceneMinLocation().getY(), false);
+		doActionClientTick(entry, rectangle, ticksToDelay);
+		iObject test;
+	}
+
+	public void doTileObjectActionClientTick(TileObject object, MenuAction menuAction, long ticksToDelay) {
+		if (object == null) {
+			return;
+		}
+		Rectangle rectangle = (object.getCanvasTilePoly().getBounds() != null) ? object.getCanvasTilePoly().getBounds() :
+				new Rectangle(client.getCenterX() - 50, client.getCenterY() - 50, 100, 100);
+		MenuEntry entry = setMenuEntry("", "", object.getId(), menuAction, object.getLocalLocation().getSceneX(), object.getLocalLocation().getSceneY(), false);
+		doActionClientTick(entry, rectangle, ticksToDelay);
+	}
+
+	public void doNpcActionClientTick(NPC npc, MenuAction menuAction, long ticksToDelay) {
+		if (npc == null || npc.getConvexHull() == null) {
+			return;
+		}
+		Rectangle rectangle = (npc.getConvexHull().getBounds() != null) ? npc.getConvexHull().getBounds() :
+				new Rectangle(client.getCenterX() - 50, client.getCenterY() - 50, 100, 100);
+		MenuEntry entry = setMenuEntry("", "", npc.getIndex(), menuAction, 0, 0, false);
+		doActionClientTick(entry, rectangle, ticksToDelay);
+	}
+
+	public void doItemActionClientTick(WidgetItem item, MenuAction menuAction, int menuParam1ID, long ticksToDelay) {
+		if (item == null) {
+			return;
+		}
+		MenuEntry entry = setMenuEntry("", "", item.getId(), menuAction, item.getIndex(), menuParam1ID, true);
+		doActionClientTick(entry, item.getCanvasBounds().getBounds(), ticksToDelay);
+	}
+
+	//Use with caution, does not pair with mouse click and is potentially detectable
+	public void doInvokeGameTick(MenuEntry entry, long ticksToDelay) {
+		Runnable runnable = () -> client.invokeMenuAction(entry.getOption(), entry.getTarget(), entry.getIdentifier(),
+				entry.getOpcode(), entry.getParam0(), entry.getParam1());
+		action.delayGameTicks(ticksToDelay, runnable);
+	}
+
+	public void doActionGameTick(MenuEntry entry, Rectangle rect, long ticksToDelay) {
+		Point point = mouse.getClickPoint(rect);
+		doActionGameTick(entry, point, ticksToDelay);
+	}
+
+	public void doActionGameTick(MenuEntry entry, Point point, long ticksToDelay) {
+		Runnable runnable = () -> {
+			menu.setEntry(entry);
+			mouse.handleMouseClick(point);
+		};
+
+		action.delayGameTicks(ticksToDelay, runnable);
+	}
+
+	public void doGameObjectActionGameTick(GameObject object, MenuAction menuAction, long ticksToDelay) {
+		if (object == null || object.getConvexHull() == null) {
+			return;
+		}
+		Rectangle rectangle = (object.getConvexHull().getBounds() != null) ? object.getConvexHull().getBounds() :
+				new Rectangle(client.getCenterX() - 50, client.getCenterY() - 50, 100, 100);
+		MenuEntry entry = setMenuEntry("", "", object.getId(), menuAction, object.getSceneMinLocation().getX(),object.getSceneMinLocation().getY(), false);
+		doActionGameTick(entry, rectangle, ticksToDelay);
+	}
+
+	public void doTileObjectActionGameTick(TileObject object, MenuAction menuAction, long ticksToDelay) {
+		if (object == null) {
+			return;
+		}
+		Rectangle rectangle = (object.getCanvasTilePoly().getBounds() != null) ? object.getCanvasTilePoly().getBounds() :
+				new Rectangle(client.getCenterX() - 50, client.getCenterY() - 50, 100, 100);
+		MenuEntry entry = setMenuEntry("", "", object.getId(), menuAction, object.getLocalLocation().getSceneX(),object.getLocalLocation().getSceneY(), false);
+
+		doActionGameTick(entry, rectangle, ticksToDelay);
+	}
+
+	public void doNpcActionGameTick(NPC npc, MenuAction menuAction, long ticksToDelay) {
+		if (npc == null || npc.getConvexHull() == null) {
+			return;
+		}
+		Rectangle rectangle = (npc.getConvexHull().getBounds() != null) ? npc.getConvexHull().getBounds() :
+				new Rectangle(client.getCenterX() - 50, client.getCenterY() - 50, 100, 100);
+		MenuEntry entry = setMenuEntry("", "", npc.getIndex(), menuAction, 0, 0, false);
+		doActionGameTick(entry, rectangle, ticksToDelay);
+	}
+
+	public void doItemActionGameTick(WidgetItem item, MenuAction menuAction, int menuParam1ID, long ticksToDelay) {
+		if (item == null) {
+			return;
+		}
+		MenuEntry entry = setMenuEntry("", "", item.getId(), menuAction,item.getIndex(), menuParam1ID, true);
+
+		doActionGameTick(entry, item.getCanvasBounds().getBounds(), ticksToDelay);
+	}
+
+	//Use with caution, does not pair with mouse click and is potentially detectable
+	public void doInvokeMsTime(MenuEntry entry, long timeToDelay) {
+		Runnable runnable = () -> client.invokeMenuAction(entry.getOption(), entry.getTarget(), entry.getIdentifier(),
+				entry.getOpcode(), entry.getParam0(), entry.getParam1());
+		action.delayTime(timeToDelay, runnable);
+	}
+
+	public void doActionMsTime(MenuEntry entry, Rectangle rect, long timeToDelay) {
+		Point point = mouse.getClickPoint(rect);
+		doActionMsTime(entry, point, timeToDelay);
+	}
+
+	public void doActionMsTime(MenuEntry entry, Point point, long timeToDelay) {
+		Runnable runnable = () -> {
+			menu.setEntry(entry);
+			mouse.handleMouseClick(point);
+		};
+
+		action.delayTime(timeToDelay, runnable);
+	}
+
+	public void doGameObjectActionMsTime(GameObject object, MenuAction menuAction, long timeToDelay) {
+		if (object == null || object.getConvexHull() == null) {
+			return;
+		}
+		Rectangle rectangle = (object.getConvexHull().getBounds() != null) ? object.getConvexHull().getBounds() :
+				new Rectangle(client.getCenterX() - 50, client.getCenterY() - 50, 100, 100);
+		MenuEntry entry = setMenuEntry("", "", object.getId(), menuAction, object.getSceneMinLocation().getX(), object.getSceneMinLocation().getY(), false);
+
+		doActionMsTime(entry, rectangle, timeToDelay);
+	}
+
+	public void doTileObjectActionMsTime(TileObject object, MenuAction menuAction, long timeToDelay) {
+		if (object == null) {
+			return;
+		}
+		Rectangle rectangle = (object.getCanvasTilePoly().getBounds() != null) ? object.getCanvasTilePoly().getBounds() :
+				new Rectangle(client.getCenterX() - 50, client.getCenterY() - 50, 100, 100);
+		MenuEntry entry = setMenuEntry("", "", object.getId(), menuAction, object.getLocalLocation().getSceneX(),object.getLocalLocation().getSceneY(), false);
+
+		doActionMsTime(entry, rectangle, timeToDelay);
+	}
+
+	public void doNpcActionMsTime(NPC npc, MenuAction menuAction, long timeToDelay) {
+		if (npc == null || npc.getConvexHull() == null) {
+			return;
+		}
+		Rectangle rectangle = (npc.getConvexHull().getBounds() != null) ? npc.getConvexHull().getBounds() :
+				new Rectangle(client.getCenterX() - 50, client.getCenterY() - 50, 100, 100);
+		MenuEntry entry = setMenuEntry("", "", npc.getIndex(), menuAction, 0, 0, false);
+		doActionMsTime(entry, rectangle, timeToDelay);
+	}
+
+	public void doItemActionMsTime(WidgetItem item, MenuAction menuAction, int menuParam1ID, long timeToDelay) {
+		if (item == null) {
+			return;
+		}
+		MenuEntry entry = setMenuEntry("", "", item.getId(), menuAction, item.getIndex(), menuParam1ID, true);
+		doActionMsTime(entry, item.getCanvasBounds().getBounds(), timeToDelay);
+	}
+
+	public void doModifiedActionGameTick(MenuEntry entry, int modifiedID, int modifiedIndex, int modifiedOpcode, Rectangle rect, long ticksToDelay) {
+		Point point = mouse.getClickPoint(rect);
+		doModifiedActionGameTick(entry, modifiedID, modifiedIndex, modifiedOpcode, point, ticksToDelay);
+	}
+
+	public void doModifiedActionGameTick(MenuEntry entry, int modifiedID, int modifiedIndex, int modifiedOpcode, Point point, long ticksToDelay) {
+		Runnable runnable = () -> {
+			menu.setModifiedEntry(entry, modifiedID, modifiedIndex, modifiedOpcode);
+			mouse.handleMouseClick(point);
+		};
+
+		action.delayGameTicks(ticksToDelay, runnable);
+	}
+
+	//Use with caution, does not pair with mouse click and is potentially detectable
+	public void doModifiedInvokeGameTick(MenuEntry entry, int modifiedID, int modifiedIndex, int modifiedOpcode, long ticksToDelay) {
+		Runnable runnable = () -> {
+			client.setSelectedItemWidget(WidgetInfo.INVENTORY.getId());
+			client.setSelectedItemSlot(modifiedIndex);
+			client.setSelectedItemID(modifiedID);
+			client.invokeMenuAction(entry.getOption(), entry.getTarget(), entry.getIdentifier(),
+					modifiedOpcode, entry.getParam0(), entry.getParam1());
+		};
+
+		action.delayGameTicks(ticksToDelay, runnable);
+	}
+
+	public void doModifiedActionMsTime(MenuEntry entry, int modifiedID, int modifiedIndex, int modifiedOpcode, Rectangle rect, long timeToDelay) {
+		Point point = mouse.getClickPoint(rect);
+		doModifiedActionMsTime(entry, modifiedID, modifiedIndex, modifiedOpcode, point, timeToDelay);
+	}
+
+	public void doModifiedActionMsTime(MenuEntry entry, int modifiedID, int modifiedIndex, int modifiedOpcode, Point point, long timeToDelay) {
+		Runnable runnable = () -> {
+			menu.setModifiedEntry(entry, modifiedID, modifiedIndex, modifiedOpcode);
+			mouse.handleMouseClick(point);
+		};
+
+		action.delayTime(timeToDelay, runnable);
+	}
+
+	//Use with caution, does not pair with mouse click and is potentially detectable
+	public void doModifiedInvokeMsTime(MenuEntry entry, int modifiedID, int modifiedIndex, int modifiedOpcode, long timeToDelay) {
+		Runnable runnable = () -> {
+			client.setSelectedItemWidget(WidgetInfo.INVENTORY.getId());
+			client.setSelectedItemSlot(modifiedIndex);
+			client.setSelectedItemID(modifiedID);
+			client.invokeMenuAction(entry.getOption(), entry.getTarget(), entry.getIdentifier(),
+					modifiedOpcode, entry.getParam0(), entry.getParam1());
+		};
+
+		action.delayTime(timeToDelay, runnable);
+	}
+
+	public void oneClickCastSpell(WidgetInfo spellWidget, MenuEntry targetMenu, long sleepLength) {
+		menu.setEntry(targetMenu, true);
+		mouse.delayMouseClick(new Rectangle(0, 0, 100, 100), sleepLength);
+		menu.setSelectedSpell(spellWidget);
+		mouse.delayMouseClick(new Rectangle(0, 0, 100, 100), calc.getRandomIntBetweenRange(20, 60));
+	}
+
+	public void oneClickCastSpell(WidgetInfo spellWidget, MenuEntry targetMenu, Rectangle targetBounds, long sleepLength) {
+		menu.setEntry(targetMenu, false);
+		menu.setSelectedSpell(spellWidget);
+		mouse.delayMouseClick(targetBounds, sleepLength);
+	}
+
+	public void setCombatStyle(int index) {
+		MenuEntry entry = interfaceUtils.getAttackStyleMenuEntry(index);
+		doActionClientTick(entry, new Point(0, 0), 0);
+	}
+
+	public void sendGameMessage(String message) {
+		String chatMessage = new ChatMessageBuilder()
+				.append(ChatColorType.HIGHLIGHT)
+				.append(message)
+				.build();
+
+		chatMessageManager
+				.queue(QueuedMessage.builder()
+						.type(ChatMessageType.CONSOLE)
+						.runeLiteFormattedMessage(chatMessage)
+						.build());
+	}
+
+	public ItemComposition getCompositionItem(int itemId) {
+		log.debug("Looking up CompositionItem: {}", itemId);
+
+		return itemManager.getItemComposition(itemId);
+	}
+
+	public int getItemPrice(int itemId, boolean useWikiPrice) {
+		log.debug("Looking up price for Item: {}", itemId);
+
+		return itemManager.getItemPriceWithSource(itemId, useWikiPrice);
+	}
+
+	//Ganom's
+	public int[] stringToIntArray(String string) {
+		return Arrays.stream(string.split(",")).map(String::trim).mapToInt(Integer::parseInt).toArray();
+	}
+
+	public List<Integer> stringToIntList(String string) {
+		return (string == null || string.trim().equals("")) ? List.of(0) :
+				Arrays.stream(string.split(",")).map(String::trim).map(Integer::parseInt).collect(Collectors.toList());
+	}
+
+	public boolean pointOnScreen(Point check) {
+		int x = check.getX(), y = check.getY();
+		return x > client.getViewportXOffset() && x < client.getViewportWidth()
+				&& y > client.getViewportYOffset() && y < client.getViewportHeight();
+	}
+
+
+	/**
+	 * RANDOM EVENT FUNCTIONS
+	 */
+	public void setRandomEvent(boolean random) {
+		randomEvent = random;
+	}
+
+	public boolean getRandomEvent() {
+		return randomEvent;
+	}
+
+	/**
+	 * Pauses execution for a random amount of time between two values.
+	 *
+	 * @param minSleep The minimum time to sleep.
+	 * @param maxSleep The maximum time to sleep.
+	 * @see #sleep(int)
+	 */
+
+	public static void sleep(int minSleep, int maxSleep) {
+		sleep(CalculationUtils.random(minSleep, maxSleep));
+	}
+
+	/**
+	 * Pauses execution for a given number of milliseconds.
+	 *
+	 * @param toSleep The time to sleep in milliseconds.
+	 */
+	public static void sleep(int toSleep) {
+		try {
+			long start = System.currentTimeMillis();
+			Thread.sleep(toSleep);
+
+			// Guarantee minimum sleep
+			long now;
+			while (start + toSleep > (now = System.currentTimeMillis())) {
+				Thread.sleep(start + toSleep - now);
+			}
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+		}
+	}
+
+	public static void sleep(long toSleep) {
+		try {
+			long start = System.currentTimeMillis();
+			Thread.sleep(toSleep);
+
+			// Guarantee minimum sleep
+			long now;
+			while (start + toSleep > (now = System.currentTimeMillis())) {
+				Thread.sleep(start + toSleep - now);
+			}
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+		}
+	}
+
+	@Subscribe
+	public void onClientTick(ClientTick event) {
+		action.onClientTick(event);
+	}
+
+	@Subscribe
+	private void onGameTick(GameTick event) {
+		tickActions = 0;
+		action.onGameTick(event);
+	}
+
+	@Subscribe
+	private void onMenuEntryAdded(MenuEntryAdded event) {
+		if (event.getOpcode() == MenuAction.CC_OP.getId() && (event.getParam1() == WidgetInfo.WORLD_SWITCHER_LIST.getId() ||
+				event.getParam1() == 11927560 || event.getParam1() == 4522007 || event.getParam1() == 24772686)) {
+			return;
+		}
+		if (menu.entry != null) {
+			client.setLeftClickMenuEntry(menu.entry);
+			if (menu.modifiedMenu) {
+				event.setModified();
+			}
+		}
+	}
+
+	@Subscribe
+	private void onMenuOptionClicked(MenuOptionClicked event) {
+		if (event.getMenuAction() == MenuAction.CC_OP && (event.getWidgetId() == WidgetInfo.WORLD_SWITCHER_LIST.getId() ||
+				event.getWidgetId() == 11927560 || event.getWidgetId() == 4522007 || event.getWidgetId() == 24772686)) {
+			//Either logging out or world-hopping which is handled by 3rd party plugins so let them have priority
+			log.info("Received world-hop/login related click. Giving them priority");
+			menu.entry = null;
+			return;
+		}
+		if (menu.entry != null) {
+			tickActions++;
+			log.debug("Actions this game tick: {}", tickActions);
+			if (menu.consumeClick) {
+				event.consume();
+				log.info("Consuming a click and not sending anything else");
+				menu.consumeClick = false;
+				return;
+			}
+			if (menu.entry.getOption().equals("Walk here")) {
+				event.consume();
+				log.debug("Walk action: {} {}", walk.coordX, walk.coordY);
+				walk.walkTile(walk.coordX, walk.coordY);
+				walk.walkAction = false;
+				menu.entry = null;
+				return;
+			}
+			if (menu.modifiedMenu) {
+				client.setSelectedItemWidget(WidgetInfo.INVENTORY.getId());
+				client.setSelectedItemSlot(menu.modifiedItemIndex);
+				client.setSelectedItemID(menu.modifiedItemID);
+				log.debug("doing a Modified MOC, mod ID: {}, mod index: {}, param1: {}", menu.modifiedItemID,
+						menu.modifiedItemIndex, menu.entry.getParam1());
+				menuAction(event, menu.entry.getOption(), menu.entry.getTarget(), menu.entry.getIdentifier(),
+						MenuAction.of(menu.modifiedOpCode), menu.entry.getParam0(), menu.entry.getParam1());
+				menu.modifiedMenu = false;
+			} else {
 //                System.out.println(String.format("%s, %s, %s, %s, %s, %s", menu.entry.getOption(), menu.entry.getTarget(), menu.entry.getIdentifier(), menu.entry.getOpcode(), menu.entry.getParam0(), menu.entry.getParam1()));
-                menuAction(event, menu.entry.getOption(), menu.entry.getTarget(), menu.entry.getIdentifier(),
-                        MenuAction.of(menu.entry.getOpcode()), menu.entry.getParam0(), menu.entry.getParam1());
-            }
-            menu.entry = null;
-        } else {
-            if (!event.isConsumed() && !action.delayedActions.isEmpty() && event.getMenuOption().equals("Walk here")) {
-                log.info("Consuming a NULL MOC event");
-                event.consume();
-            }
-        }
-    }
+				menuAction(event, menu.entry.getOption(), menu.entry.getTarget(), menu.entry.getIdentifier(),
+						MenuAction.of(menu.entry.getOpcode()), menu.entry.getParam0(), menu.entry.getParam1());
+			}
+			menu.entry = null;
+		} else {
+			if (!event.isConsumed() && !action.delayedActions.isEmpty() && event.getMenuOption().equals("Walk here")) {
+				log.info("Consuming a NULL MOC event");
+				event.consume();
+			}
+		}
+	}
 
-    public void menuAction(MenuOptionClicked menuOptionClicked, String option, String target, int identifier, MenuAction menuAction, int param0, int param1) {
-        menuOptionClicked.setMenuOption(option);
-        menuOptionClicked.setMenuTarget(target);
-        menuOptionClicked.setId(identifier);
-        menuOptionClicked.setMenuAction(menuAction);
-        menuOptionClicked.setActionParam(param0);
-        menuOptionClicked.setWidgetId(param1);
-    }
+	public void menuAction(MenuOptionClicked menuOptionClicked, String option, String target, int identifier, MenuAction menuAction, int param0, int param1) {
+		menuOptionClicked.setMenuOption(option);
+		menuOptionClicked.setMenuTarget(target);
+		menuOptionClicked.setId(identifier);
+		menuOptionClicked.setMenuAction(menuAction);
+		menuOptionClicked.setActionParam(param0);
+		menuOptionClicked.setWidgetId(param1);
+	}
+
+	public MenuEntry setMenuEntry(String option, String target, int identifier, MenuAction type, int param0, int param1, boolean forceLeftClick) {
+		return client.createMenuEntry(0).setOption("").setTarget("").setIdentifier(identifier).setType(type)
+				.setParam0(param0).setParam1(param1).setForceLeftClick(forceLeftClick);
+	}
 }

--- a/iutils/src/main/java/net/runelite/client/plugins/iutils/iUtils.java
+++ b/iutils/src/main/java/net/runelite/client/plugins/iutils/iUtils.java
@@ -652,11 +652,20 @@ public class iUtils extends Plugin {
 			return;
 		}
 		if (menu.entry != null) {
-			client.setLeftClickMenuEntry(menu.entry);
+			setLeftClickMenuEntry(menu.entry);
 			if (menu.modifiedMenu) {
 				event.setModified();
 			}
 		}
+	}
+
+	private void setLeftClickMenuEntry(MenuEntry entry) {
+		MenuEntry[] entries = client.getMenuEntries();
+		for (int i = entries.length - 1; i > 0; i--) {
+			entries[i] = entries[i-1];
+		}
+		entries[0] = entry;
+		client.setMenuEntries(entries);
 	}
 
 	@Subscribe


### PR DESCRIPTION
This is unlikely to be a comprehensive fix for iutils, but should make a start in getting things working again
From the oprs update today:
- removed the osbuddy api references as they are now removed from the client
- created menuAction setter in iutils using the new MenuAction setters. This can be then reused for plugins that use iUtils (it's easy to find/replace from "new MenuEntry" to the new method.
- adjusted all the iutils framework that I could find that uses "new MenuEntry" to the new iutils method

Created a method in iutils to try to replicate the behavior of client.setLeftClickMenuEntry as that seems to have been removed. Not sure if it works as intended though

Also commented out references to TileQuery as that was removed a few revisions ago

iUtils now compiles against the new oprs api, and will run in client. I have bumped the version number up too.

Plugins that use iUtils will need to be updated separately, but they can use the new iutils method hopefully