### PR TITLE
Fix bank deposit and NPE on client launch

### DIFF
--- a/iutils/src/main/java/net/runelite/client/plugins/iutils/ui/Bank.java
+++ b/iutils/src/main/java/net/runelite/client/plugins/iutils/ui/Bank.java
@@ -169,32 +169,48 @@ public class Bank {
     public boolean deposit(int id, int quantity) {
         checkBankOpen();
 
+        iWidget targetItem = null;
+        int count = 0;
+
         for (iWidget item : iUtils.bankInventoryitems) {
             if (item.itemId() == id) {
-                log.info("[Bank] Found item (requested = " + quantity + ", bank = " + item.quantity() + ")");
-
-                quantity = Math.min(quantity, item.quantity());
-
-                if (quantity == withdrawDefaultQuantity()) {
-                    item.interact(1); // default
-                } else if (item.quantity() <= quantity) {
-                    item.interact(7); // all
-                } else if (quantity == 1) {
-                    item.interact(2); // 1
-                } else if (quantity == 5) {
-                    item.interact(3); // 5
-                } else if (quantity == 10) {
-                    item.interact(4); // 10
-                } else if (quantity == withdrawXDefaultQuantity()) {
-                    item.interact(5); // last
-                } else {
-                    item.interact(6);
-                    game.tick(2);
-                    game.chooseNumber(quantity);
+                if (targetItem == null) {
+                    targetItem = item;
                 }
 
-                return true;
+                if (item.quantity() > 1) {
+                    count = item.quantity();
+                    break;
+                } else {
+                    count++;
+                }
             }
+        }
+
+        if (targetItem != null) {
+            log.info("[Bank] Found item (requested = " + quantity + ", inventory = " + count + ")");
+
+            quantity = Math.min(quantity, count);
+
+            if (quantity == withdrawDefaultQuantity()) {
+                targetItem.interact(1); // default
+            } else if (count <= quantity) {
+                targetItem.interact(7); // all
+            } else if (quantity == 1) {
+                targetItem.interact(2); // 1
+            } else if (quantity == 5) {
+                targetItem.interact(3); // 5
+            } else if (quantity == 10) {
+                targetItem.interact(4); // 10
+            } else if (quantity == withdrawXDefaultQuantity()) {
+                targetItem.interact(5); // last
+            } else {
+                targetItem.interact(6);
+                game.tick(2);
+                game.chooseNumber(quantity);
+            }
+
+            return true;
         }
 
         log.info("[Bank] Inventory Item not found");

--- a/iutils/src/main/java/net/runelite/client/plugins/iutils/ui/Equipment.java
+++ b/iutils/src/main/java/net/runelite/client/plugins/iutils/ui/Equipment.java
@@ -11,12 +11,10 @@ import java.util.Objects;
 
 public class Equipment {
     private final Game game;
-    private final ItemContainer equipment;
 
     @Inject
     public Equipment(Game game) {
         this.game = game;
-        this.equipment = game.container(94);
     }
 
     public boolean isEquipped(int id) {


### PR DESCRIPTION
8f9e127c9d24b5a837b1601b9933f1d174f38b51 removes an unused field that may cause nullpointer exceptions on client launch.

35347557840ce0496f670d24bd3e51f637efd85e fixes the bank deposit method. Before, when requesting to deposit a specific amount of a non-stackable item it would attempt to deposit them one by one because it only looked at the item quantity. The item quantity, however, is actually the stack size and not the number of items in our inventory. The new code counts all the items first and then attempts to deposit the requested quantity all at once.