### PR TITLE
iRooftopAgility - Added option to pick up coin stacks for leagues

### DIFF
--- a/irooftopagility/irooftopagility.gradle.kts
+++ b/irooftopagility/irooftopagility.gradle.kts
@@ -23,7 +23,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "6.1.7"
+version = "6.1.8"
 
 project.extra["PluginName"] = "iRooftop Agility"
 project.extra["PluginDescription"] = "Illumine automated rooftop agility plugin"

--- a/irooftopagility/src/main/java/net/runelite/client/plugins/irooftopagility/iRooftopAgilityConfig.java
+++ b/irooftopagility/src/main/java/net/runelite/client/plugins/irooftopagility/iRooftopAgilityConfig.java
@@ -359,6 +359,17 @@ public interface iRooftopAgilityConfig extends Config {
     }
 
     @ConfigItem(
+            keyName = "pickupCoins",
+            name = "Pick up coins (leagues)",
+            description = "Enable to pick up coins (leagues). Requires golden brick road fragment equipped",
+            position = 27,
+            title = "agilityTitle"
+    )
+    default boolean pickupCoins() {
+        return false;
+    }
+
+    @ConfigItem(
             keyName = "startButton",
             name = "Start/Stop",
             description = "Test button that changes variable value",

--- a/irooftopagility/src/main/java/net/runelite/client/plugins/irooftopagility/iRooftopAgilityPlugin.java
+++ b/irooftopagility/src/main/java/net/runelite/client/plugins/irooftopagility/iRooftopAgilityPlugin.java
@@ -470,6 +470,13 @@ public class iRooftopAgilityPlugin extends Plugin {
                 log.debug("should restock but couldn't find bank");
             }
         }
+        if (config.pickupCoins()) {
+            TileItem coins = object.getGroundItem(ItemID.COINS_995);
+            if (coins != null && currentObstacle.getLocation().distanceTo(coins.getTile().getWorldLocation()) == 0 &&
+                    (!inventory.isFull() || inventory.containsItem(ItemID.COINS_995))) {
+                    return COINS;
+            }
+        }
         if (markOfGrace != null && markOfGraceTile != null && config.mogPickup() && (!inventory.isFull() || inventory.containsItem(ItemID.MARK_OF_GRACE))) {
             if (currentObstacle.getLocation().distanceTo(markOfGraceTile.getWorldLocation()) == 0) {
                 if (markOfGraceTile.getGroundItems().contains(markOfGrace)) //failsafe sometimes onItemDespawned doesn't capture mog despawn
@@ -532,6 +539,10 @@ public class iRooftopAgilityPlugin extends Plugin {
             switch (state) {
                 case TIMEOUT:
                     timeout--;
+                    break;
+                case COINS:
+                    timeout = tickDelay();
+                    pickCoins();
                     break;
                 case MARK_OF_GRACE:
                     log.debug("Picking up mark of grace");
@@ -680,5 +691,17 @@ public class iRooftopAgilityPlugin extends Plugin {
             mogCollectCount++;
             mogInventoryCount = -1;
         }
+    }
+
+    private void pickCoins() {
+        TileItem coins = object.getGroundItem(ItemID.COINS_995);
+        if (coins != null) {
+            lootItem(coins);
+        }
+    }
+
+    private void lootItem(TileItem itemToLoot) {
+        menu.setEntry(new LegacyMenuEntry("", "", itemToLoot.getId(), MenuAction.GROUND_ITEM_THIRD_OPTION.getId(), itemToLoot.getTile().getSceneLocation().getX(), itemToLoot.getTile().getSceneLocation().getY(), false));
+        mouse.delayMouseClick(itemToLoot.getTile().getItemLayer().getCanvasTilePoly().getBounds(), sleepDelay());
     }
 }

--- a/irooftopagility/src/main/java/net/runelite/client/plugins/irooftopagility/iRooftopAgilityState.java
+++ b/irooftopagility/src/main/java/net/runelite/client/plugins/irooftopagility/iRooftopAgilityState.java
@@ -12,5 +12,6 @@ public enum iRooftopAgilityState {
     RESTOCK_ITEMS,
     TIMEOUT,
     EAT_SUMMER_PIE,
+    COINS,
     OUT_OF_SUMMER_PIES;
 }


### PR DESCRIPTION
Adds a config option to pick up coins when running the plugin. This is for Leagues where a fragment spawns gold piles