### PR TITLE
Fixed bank not closing due to iQuestAssistant breaking iHerbCleaner until client restart or user uninstalls iQuestAssistant

### DIFF
--- a/iherbcleaner/src/main/java/net/runelite/client/plugins/iherbcleaner/tasks/CleanHerbTask.java
+++ b/iherbcleaner/src/main/java/net/runelite/client/plugins/iherbcleaner/tasks/CleanHerbTask.java
@@ -6,6 +6,7 @@ import net.runelite.api.widgets.WidgetItem;
 import net.runelite.client.plugins.iherbcleaner.Task;
 import net.runelite.client.plugins.iherbcleaner.iHerbCleanerPlugin;
 import net.runelite.client.plugins.iutils.ActionQueue;
+import net.runelite.client.plugins.iutils.BankUtils;
 import net.runelite.client.plugins.iutils.InventoryUtils;
 import net.runelite.client.plugins.iutils.game.Game;
 
@@ -23,6 +24,9 @@ public class CleanHerbTask extends Task {
     @Inject
     InventoryUtils inventory;
 
+    @Inject
+    BankUtils bank;
+
     @Override
     public boolean validate() {
         return /*action.delayedActions.isEmpty()*/ !Game.isBusy() && inventory.containsItem(config.herbID());
@@ -35,14 +39,22 @@ public class CleanHerbTask extends Task {
 
     @Override
     public void onGameTick(GameTick event) {
-        status = "Starting herb cleaning";
-        var herbs = game.inventory().withId(config.herbID()).withAction("Clean").all();
-        game.executorService.submit(() -> {
-            herbs.forEach(h -> {
-                h.interact("Clean");
-                game.sleepExact(sleepDelay());
+        if(bank.isOpen()){
+            //log.debug("Closed bank");
+            bank.close();
+            game.sleepExact(sleepDelay());
+            log.info("Closed bank");
+        }
+        else {
+            status = "Starting herb cleaning";
+            var herbs = game.inventory().withId(config.herbID()).withAction("Clean").all();
+            game.executorService.submit(() -> {
+                herbs.forEach(h -> {
+                    h.interact("Clean");
+                    game.sleepExact(sleepDelay());
+                });
             });
-        });
+        }
         log.info(status);
     }
 }


### PR DESCRIPTION
iHerbCleaner fix v2.2

Bank closes and continues as normal now when iQuestAssistant is disabled, which wasn't the case since if the user downloaded IQA and activated it, something in IQA broke iHerbCleaner until you restarted the client and deactivated/uninstalled IQA.

BUG:
Running both iQuester and iHerb still bugs out at bank screen (Better than restarting the client or uninstalling the iQuester plugin I guess).
Bank screen opens, but doesn't close, but disabling iQuester fixes it.